### PR TITLE
Update publish & deploy workflow to get rid of the :latest GHCR image tag

### DIFF
--- a/.github/scripts/deploy/testing/deploy.sh
+++ b/.github/scripts/deploy/testing/deploy.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 APP_ENV="testing"
 AWS_REGION="eu-north-1"
 APP_DIR="/opt/linklite"
-IMAGE="ghcr.io/raresmusea/linklite:latest-testing"
 GHCR_USER="raresmusea"
+
+: "${IMAGE_TAG:?IMAGE_TAG is required}"
+IMAGE="ghcr.io/${GHCR_USER}/linklite:${IMAGE_TAG}"
 
 cd "$APP_DIR"
 
@@ -57,7 +59,7 @@ services:
     env_file:
       - .env
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     depends_on:
       db:
         condition: service_healthy
@@ -69,6 +71,9 @@ volumes:
 EOF
 
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+echo "Deploying image: $IMAGE"
+
 docker pull "$IMAGE"
 
 sudo docker-compose -f docker-compose.testing.yml up -d db

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  DATABASE_URL: ${{secrets.DATABASE_URL}}
+
 jobs:
   pre-requisites:
     name: Pre-requisites (setup & install)
@@ -63,8 +66,6 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma
-        env:
-          DATABASE_URL: "postgresql://user:pass@localhost:5432/db?schema=public" #TODO: Change this later on
         run: pnpm prisma generate
 
       - name: Linter
@@ -170,13 +171,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run migrations
-        env:
-          DATABASE_URL: postgresql://linklite:linklite@localhost:5432/linklite_test?schema=public
         run: pnpm prisma migrate deploy
 
       - name: Integration tests
-        env:
-          DATABASE_URL: postgresql://linklite:linklite@localhost:5432/linklite_test?schema=public
         run: pnpm test:integration
 
   build:

--- a/.github/workflows/deploy.testing.yml
+++ b/.github/workflows/deploy.testing.yml
@@ -19,6 +19,12 @@ jobs:
       contents: read
 
     steps:
+      - name: Debug GitHub context
+        run: |
+          echo "repo=${{ github.repository }}"
+          echo "event=${{ github.event_name }}"
+          echo "ref=${{ github.ref }}"
+    
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy.testing.yml
+++ b/.github/workflows/deploy.testing.yml
@@ -19,12 +19,6 @@ jobs:
       contents: read
 
     steps:
-      - name: Debug GitHub context
-        run: |
-          echo "repo=${{ github.repository }}"
-          echo "event=${{ github.event_name }}"
-          echo "ref=${{ github.ref }}"
-    
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/deploy.testing.yml
+++ b/.github/workflows/deploy.testing.yml
@@ -9,10 +9,16 @@ concurrency:
   group: deploy-testing
   cancel-in-progress: true
 
+env:
+  IMAGE_TAG: testing-${{ github.event.workflow_run.head_sha }}
+  HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+  REPO: ${{ github.repository }}
+
 jobs:
   deploy:
     if: |
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_branch == 'testing'
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # OIDC
@@ -31,12 +37,14 @@ jobs:
             --region eu-north-1 \
             --instance-ids "${{ secrets.AWS_TESTING_EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
-            --parameters 'commands=[
-              "set -e",
-              "sudo mkdir -p /opt/linklite",
-              "sudo chown ec2-user:ec2-user /opt/linklite",
-              "cd /opt/linklite",
-              "curl -fsSL https://raw.githubusercontent.com/RaresMusea/linklite/feature/cd-testing/.github/scripts/deploy/testing/deploy.sh -o deploy.sh",
-              "chmod +x deploy.sh",
-              "./deploy.sh"
-            ]'
+            --comment "Deploy LinkLite testing ${HEAD_SHA}" \
+            --parameters commands="[
+              \"set -e\",
+              \"export IMAGE_TAG=${IMAGE_TAG}\",
+              \"sudo mkdir -p /opt/linklite\",
+              \"sudo chown ec2-user:ec2-user /opt/linklite\",
+              \"cd /opt/linklite\",
+              \"curl -fsSL https://raw.githubusercontent.com/${REPO}/${HEAD_SHA}/.github/scripts/deploy/testing/deploy.sh -o deploy.sh\",
+              \"chmod +x deploy.sh\",
+              \"./deploy.sh\"
+            ]"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,14 +31,14 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          REPO="ghcr/io/${{github.repository_owner}}/linklite"
+          REPO="ghcr.io/${{github.repository_owner}}/linklite"
           SHA="${{github.sha}}"
-          BRANCH=${{github.ref_name}}"
+          BRANCH="${{github.ref_name}}"
           
           TAG_SHA="${REPO}:${BRANCH}-${SHA}"
           TAG_BRANCH="${REPO}:${BRANCH}"
           
-          echo "tags=${TAG_SHA}, ${TAG_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "tags=${TAG_SHA},${TAG_BRANCH}" >> "$GITHUB_OUTPUT"
           echo "tag_sha=${TAG_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build & push (multi-arch)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,8 +31,15 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          chmod +x .github/scripts/publish/compute_oci_tag.sh
-          .github/scripts/publish/compute_oci_tag.sh >> "$GITHUB_OUTPUT"
+          REPO="ghcr/io/${{github.repository_owner}}/linklite"
+          SHA="${{github.sha}}"
+          BRANCH=${{github.ref_name}}"
+          
+          TAG_SHA="${REPO}:${BRANCH}-${SHA}"
+          TAG_BRANCH="${REPO}:${BRANCH}"
+          
+          echo "tags=${TAG_SHA}, ${TAG_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=${TAG_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Build & push (multi-arch)
         uses: docker/build-push-action@v6
@@ -42,4 +49,4 @@ jobs:
           platforms: linux/arm64,linux/amd64
           tags: ${{ steps.tags.outputs.tags }}
           build-args: |
-            DATABASE_URL=postgresql://user:pass@localhost:5432/db?schema=public
+            DATABASE_URL=${{secrets.DATABASE_URL}}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
     children: React.ReactNode;
 }>) {
     return (
-        <html lang="en" suppressHydrationWarning className="scroll-smooth">
+        <html lang="en" suppressHydrationWarning>
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
                 <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
                     <Header />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
     children: React.ReactNode;
 }>) {
     return (
-        <html lang="en" suppressHydrationWarning>
+        <html lang="en" suppressHydrationWarning className="scroll-smooth">
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
                 <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
                     <Header />

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -26,3 +26,14 @@ export function isApiRouteResponseOf<T>(x: unknown, isData: (v: unknown) => v is
 
     return 'error' in x && typeof x.error === 'string' && (x.status === undefined || typeof x.status === 'number');
 }
+
+export function generateSlug(length = 6): string {
+    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    let slug: string = '';
+
+    for (let i = 0; i < length; i++) {
+        slug += chars[Math.floor(Math.random() * chars.length)];
+    }
+
+    return slug;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,17 +7,6 @@ export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
 
-export function generateSlug(length = 6): string {
-    const chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    let slug: string = '';
-
-    for (let i = 0; i < length; i++) {
-        slug += chars[Math.floor(Math.random() * chars.length)];
-    }
-
-    return slug;
-}
-
 export function isApiRouteResponseOf<T>(x: unknown, isData: (v: unknown) => v is T): x is ApiRouteResponse<T> {
     if (!isPlainObject(x)) return false;
     if (typeof x.success !== 'boolean') return false;


### PR DESCRIPTION
## Closes #25 
---
- Replace `DATABASE_URL` env with actual GitHub secret.
- Update compute tags step from publish workflow to use `testing:<SHA>` / `main:<SHA>` image labeling
- Update test deployment workflow & script