### PR TITLE
Implement an API route for checking whether the app is available or not (health check)

### DIFF
--- a/.github/scripts/deploy/testing/deploy.sh
+++ b/.github/scripts/deploy/testing/deploy.sh
@@ -5,6 +5,7 @@ APP_ENV="testing"
 AWS_REGION="eu-north-1"
 APP_DIR="/opt/linklite"
 GHCR_USER="raresmusea"
+URL="https://staging.linklite.dev/api/app/healthz"
 
 : "${IMAGE_TAG:?IMAGE_TAG is required}"
 IMAGE="ghcr.io/${GHCR_USER}/linklite:${IMAGE_TAG}"
@@ -85,3 +86,21 @@ sudo docker-compose -f docker-compose.testing.yml up -d db
 sudo docker-compose -f docker-compose.testing.yml run --rm app pnpm prisma migrate deploy
 
 sudo docker-compose -f docker-compose.testing.yml up -d --no-deps --force-recreate app
+
+echo "Waiting for app to respond: $URL"
+for i in {1..30}; do
+  if curl -fsS --max-time 3 "$URL" > /dev/null; then
+    echo "Smoke check OK"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Smoke check FAILED"
+echo "Last attempt details:"
+curl -v --max-time 10 "$URL" || true
+
+echo "Fetching health payload (if reachable):"
+curl -sS --max-time 10 "$URL" || true
+
+exit 1

--- a/app/api/app/healthz/route.ts
+++ b/app/api/app/healthz/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(): Promise<NextResponse> {
+    try {
+        return NextResponse.json(
+            {
+                ok: true,
+                service: `linklite-${process.env.APP_ENV ?? ''}`,
+                env: process.env.APP_ENV ?? 'unknown',
+                version: process.env.APP_VERSION ?? 'unknown',
+                commit: process.env.APP_COMMIT ?? 'unknown',
+                uptime: process.uptime(),
+                nodeVersion: process.version,
+                time: new Date().toISOString(),
+            },
+            { status: 200 }
+        );
+    } catch (error) {
+        console.error('[HEALTH_CHECK_ERROR]', error);
+
+        return NextResponse.json(
+            {
+                ok: false,
+                error: 'Internal server error',
+                time: new Date().toISOString(),
+            },
+            { status: 500 }
+        );
+    }
+}

--- a/tests/unit/app/api/app/healthz/route.test.ts
+++ b/tests/unit/app/api/app/healthz/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '@/app/api/app/healthz/route';
+
+describe('GET /api/app/healthz (unit)', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-01-14T10:00:00.000Z'));
+
+        vi.spyOn(process, 'uptime').mockReturnValue(123.456);
+
+        process.env.APP_ENV = 'test';
+        process.env.APP_VERSION = '1.2.3';
+        process.env.APP_COMMIT = 'abc123';
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('returns 200 and expected payload', async () => {
+        const res = await GET();
+
+        expect(res.status).toBe(200);
+
+        const body = await res.json();
+
+        expect(body.ok).toBe(true);
+        expect(body.env).toBe('test');
+        expect(body.version).toBe('1.2.3');
+        expect(body.commit).toBe('abc123');
+
+        expect(body.uptime).toBe(123.456);
+        expect(body.nodeVersion).toBe(process.version);
+        expect(body.time).toBe('2026-01-14T10:00:00.000Z');
+
+        // service format
+        expect(body.service).toBe('linklite-test');
+    });
+
+    describe('GET /api/health (unit - error case)', () => {
+        beforeEach(() => {
+            vi.spyOn(process, 'uptime').mockImplementation(() => {
+                throw new Error('boom');
+            });
+
+            // Spy pe console.error ca să nu polueze output-ul de test
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('returns 500 and error payload when an exception is thrown', async () => {
+            const res = await GET();
+
+            expect(res.status).toBe(500);
+
+            const body = await res.json();
+
+            expect(body.ok).toBe(false);
+            expect(body.error).toBe('Internal server error');
+            expect(body.time).toBeDefined();
+
+            expect(body.time).toMatch(/Z$/);
+
+            expect(console.error).toHaveBeenCalledWith('[HEALTH_CHECK_ERROR]', expect.any(Error));
+        });
+    });
+});


### PR DESCRIPTION
## Closes #38 

- Provide app health check API route + tests
- Add app health check directly within the staging deployment script (`deploy.sh`)