### PR TITLE
Extend links table to include a click counter

### DIFF
--- a/prisma/migrations/20260115115810_add_clicks_to_links/migration.sql
+++ b/prisma/migrations/20260115115810_add_clicks_to_links/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Link" ADD COLUMN     "clicks" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ model Link {
   id        String   @id @default(cuid())
   slug      String   @unique
   targetUrl String   @map("target_url")
+  clicks    Int      @default(0)
   createdAt DateTime @default(now()) @map("created_at")
   ownerId   String?  @map("owner_id") // WILL BE USED LATER ON
 }


### PR DESCRIPTION
## Closes #53
- Modify schema prisma to add a click counter to the `links` table
- Add new db migration