### PR TITLE
Replace staging link shortening result with actual proxy domain

### DIFF
--- a/app/api/shorten/route.ts
+++ b/app/api/shorten/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { LinkCreationSchema } from '@/validation/LinkCreationSchema';
 import { CreatedLink } from '@/dal/links/links.types';
 import { createLink } from '@/dal/links/links.repo';
+import { getOrigin } from '@/lib/origin';
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     const json: unknown = await request.json().catch(() => null);
@@ -49,7 +50,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         return NextResponse.json({ error: 'Could not generate a unique slug. Please try again.' }, { status: 500 });
     }
 
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000';
+    const baseUrl = getOrigin(request) ?? 'http://localhost:3000';
 
     return NextResponse.json(
         {

--- a/lib/origin.ts
+++ b/lib/origin.ts
@@ -1,0 +1,11 @@
+import { NextRequest } from 'next/server';
+
+export function getOrigin(req: NextRequest): string | null {
+    return getOriginFromHeaders(req.headers, req.nextUrl.protocol.replace(':', ''));
+}
+
+export function getOriginFromHeaders(headers: Headers, fallbackProtocol: string): string | null {
+    const proto = headers.get('x-forwarded-proto') ?? fallbackProtocol;
+    const host = headers.get('x-forwarded-host') ?? headers.get('host');
+    return host ? `${proto}://${host}` : null;
+}

--- a/tests/unit/app/api/shorten/route.test.ts
+++ b/tests/unit/app/api/shorten/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { createLink } from '@/dal/links/links.repo';
+import { generateSlug } from '@/lib/utils';
+import { POST } from '@/app/api/shorten/route';
 import type { CreateLinkInput, CreatedLink } from '@/dal/links/links.types';
+import { NextRequest } from 'next/server';
 
 type CreateLinkFn = (input: CreateLinkInput) => Promise<CreatedLink>;
 type GenerateSlugFn = (input: number) => string;
@@ -13,14 +17,15 @@ vi.mock('@/lib/utils', () => ({
     generateSlug: vi.fn<GenerateSlugFn>(),
 }));
 
-import { createLink } from '@/dal/links/links.repo';
-import { generateSlug } from '@/lib/utils';
-import { POST } from '@/app/api/shorten/route';
-
-function req(body: unknown): Request {
-    return new Request('http://localhost/api/shorten', {
+function req(body: unknown): NextRequest {
+    return new NextRequest('http://localhost:3000/api/shorten', {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: {
+            'content-type': 'application/json',
+            // important pt getOriginFromHeaders():
+            host: 'localhost:3000',
+            'x-forwarded-proto': 'http',
+        },
         body: JSON.stringify(body),
     });
 }

--- a/tests/unit/lib/origin.test.ts
+++ b/tests/unit/lib/origin.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { getOriginFromHeaders } from '@/lib/origin';
+
+describe('getOriginFromHeaders', () => {
+    it('uses x-forwarded headers when present', () => {
+        const headers = new Headers({
+            'x-forwarded-proto': 'https',
+            'x-forwarded-host': 'staging.linklite.dev',
+        });
+
+        expect(getOriginFromHeaders(headers, 'http')).toBe('https://staging.linklite.dev');
+    });
+
+    it('falls back to host header', () => {
+        const headers = new Headers({
+            host: 'localhost:3000',
+        });
+
+        expect(getOriginFromHeaders(headers, 'http')).toBe('http://localhost:3000');
+    });
+
+    it('returns null when no host is present', () => {
+        const headers = new Headers();
+
+        expect(getOriginFromHeaders(headers, 'http')).toBeNull();
+    });
+});


### PR DESCRIPTION
## Closes #42 
- Even though the EC2 instance has an internal `.env` file, responsible for holding out the app domain, the app context does not hold that between subsequent redeployments.
- In order do fix that, the instance naming will get called via util function by all requests which actually need the external app domain (DN - domain name).
- Update API route responsible for shortening out links
- Fix failing tests