### PR TITLE
Add condition for running integration tests on push to develop by specifying a given buzz-word

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ env:
 
 jobs:
   should-run-on-push:
+    permissions:
+      contents: read
+      pull-requests: read
     name: Detect open PR for branch
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,14 @@ jobs:
     needs: checks
     if: |
       github.event_name == 'push' &&
-      (github.ref == 'refs/heads/testing' || github.ref == 'refs/heads/main')
+      (
+        github.ref == 'refs/heads/testing' ||
+        github.ref == 'refs/heads/main' ||
+        (
+          github.ref == 'refs/heads/develop' &&
+          contains(github.event.head_commit.message, '[run-it]')
+        )
+      )
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,15 +45,18 @@ jobs:
             echo "has_pr=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-
+          
           BRANCH="${GITHUB_REF#refs/heads/}"
           echo "Checking open PRs for branch: $BRANCH"
-
-          PRS=$(gh api \
-            repos/${{ github.repository }}/pulls \
-            -f state=open \
-            -f head=${{ github.repository_owner }}:"$BRANCH" \
-            --jq 'length')
+          
+          QUERY="repo:${{ github.repository }} is:pr is:open head:${{ github.repository_owner }}:$BRANCH"
+          PRS=$(gh api "search/issues?q=$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
+          
+          if [ "$PRS" -gt 0 ]; then
+          echo "has_pr=true" >> $GITHUB_OUTPUT
+          else
+          echo "has_pr=false" >> $GITHUB_OUTPUT
+          fi
 
           if [ "$PRS" -gt 0 ]; then
             echo "has_pr=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,7 +251,7 @@ jobs:
           echo "run=$RUN" >> $GITHUB_OUTPUT
 
   integration-tests:
-    name: Integration Tests (only push to testing/main)
+    name: Integration Tests
     needs:
       - checks
       - should-run-on-push
@@ -346,4 +346,4 @@ jobs:
         run: pnpm prisma generate
 
       - name: Build
-        run: pnpm run build # Run build
+        run: pnpm run build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,7 @@ jobs:
         github.ref == 'refs/heads/testing' ||
         github.ref == 'refs/heads/main' ||
         (
-          github.ref == 'refs/heads/develop' &&
+          (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/feature/')) &&
           contains(github.event.head_commit.message, '[run-it]')
         )
       )

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,37 @@ env:
   DATABASE_URL: ${{secrets.DATABASE_URL}}
 
 jobs:
+  should-run-on-push:
+    name: Detect open PR for branch
+    runs-on: ubuntu-latest
+    outputs:
+      has_pr: ${{ steps.pr.outputs.has_pr }}
+    steps:
+      - id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # On PR events, we don't want to block anything using has_pr
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          echo "Checking open PRs for branch: $BRANCH"
+
+          PRS=$(gh api \
+            repos/${{ github.repository }}/pulls \
+            -f state=open \
+            -f head=${{ github.repository_owner }}:"$BRANCH" \
+            --jq 'length')
+
+          if [ "$PRS" -gt 0 ]; then
+            echo "has_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+          fi
+
   pre-requisites:
     name: Pre-requisites (setup & install)
     runs-on: ubuntu-latest
@@ -47,7 +78,19 @@ jobs:
 
   checks:
     name: Checks (lint & typecheck)
-    needs: pre-requisites
+    needs:
+      - pre-requisites
+      - should-run-on-push
+    if: |
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'push' &&
+        (
+          github.ref == 'refs/heads/main' ||
+          github.ref == 'refs/heads/testing' ||
+          needs.should-run-on-push.outputs.has_pr == 'false'
+        )
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -80,7 +123,19 @@ jobs:
 
   ui-tests:
     name: UI Tests
-    needs: checks
+    needs:
+      - checks
+      - should-run-on-push
+    if: |
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'push' &&
+        (
+          github.ref == 'refs/heads/main' ||
+          github.ref == 'refs/heads/testing' ||
+          needs.should-run-on-push.outputs.has_pr == 'false'
+        )
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -107,7 +162,19 @@ jobs:
 
   unit-tests:
     name: Unit Tests
-    needs: checks
+    needs:
+      - checks
+      - should-run-on-push
+    if: |
+      github.event_name == 'pull_request' ||
+      (
+        github.event_name == 'push' &&
+        (
+          github.ref == 'refs/heads/main' ||
+          github.ref == 'refs/heads/testing' ||
+          needs.should-run-on-push.outputs.has_pr == 'false'
+        )
+      )
     runs-on: ubuntu-latest
 
     steps:
@@ -135,22 +202,59 @@ jobs:
       - name: Unit tests
         run: pnpm test:unit
 
+  integration-gate:
+    name: Decide whether the integration tests should run or not
+    runs-on: ubuntu-latest
+    needs:
+      - should-run-on-push
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Default: don't run
+          RUN="false"
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            REF="${{ github.ref }}"
+
+            # Always on main/testing pushes
+            if [ "$REF" = "refs/heads/main" ] || [ "$REF" = "refs/heads/testing" ]; then
+              RUN="true"
+            else
+              # Optional on push if no PR open + commit contains [run-it]
+              MSG="${{ github.event.head_commit.message }}"
+              if [ "${{ needs.should-run-on-push.outputs.has_pr }}" = "false" ] && echo "$MSG" | grep -q "\[run-it\]"; then
+                RUN="true"
+              fi
+            fi
+
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Run on PR only if LAST commit message contains [run-it]
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+
+            LAST_MSG=$(gh api \
+              repos/${{ github.repository }}/pulls/$PR_NUMBER/commits \
+              --jq '.[-1].commit.message')
+
+            if echo "$LAST_MSG" | grep -q "\[run-it\]"; then
+              RUN="true"
+            fi
+          fi
+
+          echo "run=$RUN" >> $GITHUB_OUTPUT
+
   integration-tests:
     name: Integration Tests (only push to testing/main)
-    needs: checks
+    needs:
+      - checks
+      - should-run-on-push
+      - integration-gate
     env:
-      DATABASE_URL: postgresql://linklite:linklite@localhost:5432/linklite_test
-    if: |
-      github.event_name == 'push' &&
-      (
-        github.ref == 'refs/heads/testing' ||
-        github.ref == 'refs/heads/main' ||
-        (
-          (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/feature/')) &&
-          contains(github.event.head_commit.message, '[run-it]')
-        )
-      )
-
+      DATABASE_URL: ${{secrets.DATABASE_URL}}
+    if: needs.integration-gate.outputs.run == 'true'
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,7 @@ concurrency:
 env:
   DATABASE_URL: ${{secrets.DATABASE_URL}}
 
+
 jobs:
   should-run-on-push:
     permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,6 +144,7 @@ jobs:
           contains(github.event.head_commit.message, '[run-it]')
         )
       )
+
     runs-on: ubuntu-latest
 
     services:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ on:
       - develop
       - testing
       - main
-      - "feature/**"
     paths-ignore:
       - "**/*.md"
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,26 +40,32 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # On PR events, we don't want to block anything using has_pr
-          if [ "${{ github.event_name }}" != "push" ]; then
-            echo "has_pr=false" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          BRANCH="${GITHUB_REF#refs/heads/}"
-          echo "Checking open PRs for branch: $BRANCH"
-
-          PRS=$(gh api \
-            repos/${{ github.repository }}/pulls \
-            -f state=open \
-            -f head=${{ github.repository_owner }}:"$BRANCH" \
-            --jq 'length')
-
-          if [ "$PRS" -gt 0 ]; then
-            echo "has_pr=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_pr=false" >> $GITHUB_OUTPUT
-          fi
+               # Only relevant on push
+               if [ "${{ github.event_name }}" != "push" ]; then
+               echo "has_pr=false" >> $GITHUB_OUTPUT
+               exit 0
+               fi
+               
+               BRANCH="${GITHUB_REF#refs/heads/}"
+               echo "Checking open PRs for branch: $BRANCH"
+          
+          # main/testing don't need PR detection
+               if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "testing" ]; then
+               echo "has_pr=false" >> $GITHUB_OUTPUT
+               exit 0
+               fi
+          
+          # Use Search API (more permissive than /pulls)
+               QUERY="repo:${{ github.repository }} is:pr is:open head:${{ github.repository_owner }}:$BRANCH"
+          
+          # timeout + fallback so CI never fails here
+               PRS=$(timeout 8s gh api "search/issues?q=$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
+               
+               if [ "$PRS" -gt 0 ]; then
+               echo "has_pr=true" >> $GITHUB_OUTPUT
+               else
+               echo "has_pr=false" >> $GITHUB_OUTPUT
+               fi
 
   pre-requisites:
     name: Pre-requisites (setup & install)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,8 @@ jobs:
         run: |
           # Only relevant on push
           if [ "${{ github.event_name }}" != "push" ]; then
-          echo "has_pr=false" >> $GITHUB_OUTPUT
-          exit 0
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
           
           BRANCH="${GITHUB_REF#refs/heads/}"
@@ -51,20 +51,23 @@ jobs:
           
           # main/testing don't need PR detection
           if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "testing" ]; then
-          echo "has_pr=false" >> $GITHUB_OUTPUT
-          exit 0
+            echo "has_pr=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
           
           # Use Search API (more permissive than /pulls)
           QUERY="repo:${{ github.repository }} is:pr is:open head:${{ github.repository_owner }}:$BRANCH"
           
-          # timeout + fallback so CI never fails here
-          PRS=$(timeout 8s gh api "search/issues?q=$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
+          if command -v timeout >/dev/null 2>&1; then
+            PRS=$(timeout 8s gh api search/issues -f q="$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
+          else
+            PRS=$(gh api search/issues -f q="$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
+          fi
           
           if [ "$PRS" -gt 0 ]; then
-          echo "has_pr=true" >> $GITHUB_OUTPUT
+            echo "has_pr=true" >> $GITHUB_OUTPUT
           else
-          echo "has_pr=false" >> $GITHUB_OUTPUT
+            echo "has_pr=false" >> $GITHUB_OUTPUT
           fi
 
   pre-requisites:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [ "develop", "testing", "main" ]
+    branches:
+      - develop
+      - testing
+      - main
+      - "feature/**"
     paths-ignore:
       - "**/*.md"
   pull_request:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,18 +45,15 @@ jobs:
             echo "has_pr=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          
+
           BRANCH="${GITHUB_REF#refs/heads/}"
           echo "Checking open PRs for branch: $BRANCH"
-          
-          QUERY="repo:${{ github.repository }} is:pr is:open head:${{ github.repository_owner }}:$BRANCH"
-          PRS=$(gh api "search/issues?q=$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
-          
-          if [ "$PRS" -gt 0 ]; then
-          echo "has_pr=true" >> $GITHUB_OUTPUT
-          else
-          echo "has_pr=false" >> $GITHUB_OUTPUT
-          fi
+
+          PRS=$(gh api \
+            repos/${{ github.repository }}/pulls \
+            -f state=open \
+            -f head=${{ github.repository_owner }}:"$BRANCH" \
+            --jq 'length')
 
           if [ "$PRS" -gt 0 ]; then
             echo "has_pr=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,6 +192,7 @@ jobs:
       - name: Run migrations
         run: pnpm prisma migrate deploy
 
+
       - name: Integration tests
         env:
           RUN_WHOIS_INTEGRATION: "1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,32 +40,32 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-               # Only relevant on push
-               if [ "${{ github.event_name }}" != "push" ]; then
-               echo "has_pr=false" >> $GITHUB_OUTPUT
-               exit 0
-               fi
-               
-               BRANCH="${GITHUB_REF#refs/heads/}"
-               echo "Checking open PRs for branch: $BRANCH"
+          # Only relevant on push
+          if [ "${{ github.event_name }}" != "push" ]; then
+          echo "has_pr=false" >> $GITHUB_OUTPUT
+          exit 0
+          fi
+          
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          echo "Checking open PRs for branch: $BRANCH"
           
           # main/testing don't need PR detection
-               if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "testing" ]; then
-               echo "has_pr=false" >> $GITHUB_OUTPUT
-               exit 0
-               fi
+          if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "testing" ]; then
+          echo "has_pr=false" >> $GITHUB_OUTPUT
+          exit 0
+          fi
           
           # Use Search API (more permissive than /pulls)
-               QUERY="repo:${{ github.repository }} is:pr is:open head:${{ github.repository_owner }}:$BRANCH"
+          QUERY="repo:${{ github.repository }} is:pr is:open head:${{ github.repository_owner }}:$BRANCH"
           
           # timeout + fallback so CI never fails here
-               PRS=$(timeout 8s gh api "search/issues?q=$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
-               
-               if [ "$PRS" -gt 0 ]; then
-               echo "has_pr=true" >> $GITHUB_OUTPUT
-               else
-               echo "has_pr=false" >> $GITHUB_OUTPUT
-               fi
+          PRS=$(timeout 8s gh api "search/issues?q=$QUERY" --jq '.total_count' 2>/dev/null || echo "0")
+          
+          if [ "$PRS" -gt 0 ]; then
+          echo "has_pr=true" >> $GITHUB_OUTPUT
+          else
+          echo "has_pr=false" >> $GITHUB_OUTPUT
+          fi
 
   pre-requisites:
     name: Pre-requisites (setup & install)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,6 +138,8 @@ jobs:
   integration-tests:
     name: Integration Tests (only push to testing/main)
     needs: checks
+    env:
+      DATABASE_URL: postgresql://linklite:linklite@localhost:5432/linklite_test
     if: |
       github.event_name == 'push' &&
       (

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ permissions:
   contents: read
   pull-requests: read
 
+
 on:
   push:
     branches:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: CI
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   push:
     branches:

--- a/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
+++ b/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
@@ -161,35 +161,6 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
             testDomainId3 = domain3.id;
         });
 
-        afterAll(async () => {
-            // Clean up all test data
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: {
-                    domainId: {
-                        in: [testDomainId1, testDomainId2, testDomainId3],
-                    },
-                },
-            });
-            await prisma.domain.deleteMany({
-                where: {
-                    id: {
-                        in: [testDomainId1, testDomainId2, testDomainId3],
-                    },
-                },
-            });
-        });
-
-        beforeEach(async () => {
-            // Clear all jobs before each test
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: {
-                    domainId: {
-                        in: [testDomainId1, testDomainId2, testDomainId3],
-                    },
-                },
-            });
-        });
-
         it('Should claim the next PENDING job', async () => {
             // Arrange
             vi.useFakeTimers();

--- a/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
+++ b/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
@@ -14,19 +14,18 @@ const testDomainId = 'test-integration-domain-id';
 
 describe('Domain Enrichment Jobs repository integration tests', () => {
     beforeEach(async () => {
+        await resetDb();
         await prisma.domain.upsert({
             where: { id: testDomainId },
             create: {
                 id: testDomainId,
                 hostname: 'test-integration.example.com',
+                firstSeenAt: new Date(),
             },
             update: {},
         });
     });
 
-    afterEach(async () => {
-        await resetDb();
-    });
 
     describe('Upsert Domain Enrichment job', () => {
         it('Should create a new job when none exists', async () => {
@@ -641,7 +640,7 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
             // Test from PENDING
             const pendingJob = await prisma.domainEnrichmentJob.update({
                 where: { id: job.id },
-                data: {status: DomainEnrichmentJobStatus.PENDING },
+                data: { status: DomainEnrichmentJobStatus.PENDING },
             });
 
             // Act

--- a/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
+++ b/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
@@ -1,4 +1,4 @@
-import { describe, beforeEach, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { describe, beforeEach, it, expect, afterAll, vi, afterEach } from 'vitest';
 import { prisma } from '@/lib/prisma';
 import { DomainEnrichmentJobStatus } from '@/generated/prisma/enums';
 import {
@@ -7,46 +7,28 @@ import {
     requeueDomainEnrichmentJob,
     upsertDomainEnrichmentJob,
 } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
+import { resetDb } from '@/tests/helpers/db';
+import { DomainEnrichmentJob } from '@/generated/prisma/client';
+
+const testDomainId = 'test-integration-domain-id';
 
 describe('Domain Enrichment Jobs repository integration tests', () => {
+    beforeEach(async () => {
+        await prisma.domain.upsert({
+            where: { id: testDomainId },
+            create: {
+                id: testDomainId,
+                hostname: 'test-integration.example.com',
+            },
+            update: {},
+        });
+    });
+
+    afterEach(async () => {
+        await resetDb();
+    });
+
     describe('Upsert Domain Enrichment job', () => {
-        const testDomainId = 'test-integration-domain-id';
-
-        beforeAll(async () => {
-            // Clean up any existing test data
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: { domainId: testDomainId },
-            });
-
-            // Ensure test domain exists
-            await prisma.domain.upsert({
-                where: { id: testDomainId },
-                create: {
-                    id: testDomainId,
-                    hostname: 'test-integration.example.com',
-                },
-                update: {},
-            });
-        });
-
-        afterAll(async () => {
-            // Clean up test data
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: { domainId: testDomainId },
-            });
-
-            await prisma.domain.deleteMany({
-                where: { id: testDomainId },
-            });
-        });
-
-        beforeEach(async () => {
-            // Ensure no job exists before each test
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: { domainId: testDomainId },
-            });
-        });
-
         it('Should create a new job when none exists', async () => {
             // Arrange
             const input = {
@@ -155,7 +137,7 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
         let testDomainId2: string;
         let testDomainId3: string;
 
-        beforeAll(async () => {
+        beforeEach(async () => {
             // Create test domains
             const domain1 = await prisma.domain.create({
                 data: {
@@ -648,36 +630,11 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
     });
 
     describe('Mark domain enrichment job as done ', () => {
-        let testDomainId: string;
         let testJobId: string;
-
-        beforeAll(async () => {
-            // Create test domain
-            const domain = await prisma.domain.create({
-                data: {
-                    hostname: 'done-test.example.com',
-                },
-            });
-            testDomainId = domain.id;
-        });
-
-        afterAll(async () => {
-            // Clean up
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: { domainId: testDomainId },
-            });
-            await prisma.domain.delete({
-                where: { id: testDomainId },
-            });
-        });
+        let job: DomainEnrichmentJob;
 
         beforeEach(async () => {
-            // Create a fresh job for each test
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: { domainId: testDomainId },
-            });
-
-            const job = await prisma.domainEnrichmentJob.create({
+            job = await prisma.domainEnrichmentJob.create({
                 data: {
                     domainId: testDomainId,
                     status: DomainEnrichmentJobStatus.RUNNING,
@@ -688,6 +645,10 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
                 },
             });
             testJobId = job.id;
+        });
+
+        afterEach(async () => {
+            await resetDb();
         });
 
         it('Should mark job as DONE and clear lock/error', async () => {
@@ -706,20 +667,10 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
         });
 
         it('Should work from different initial statuses', async () => {
-            // Arrange - Delete the existing job first since domain_id has UNIQUE constraint
-            await prisma.domainEnrichmentJob.delete({
-                where: { id: testJobId },
-            });
-
             // Test from PENDING
-            const pendingJob = await prisma.domainEnrichmentJob.create({
-                data: {
-                    domainId: testDomainId,
-                    status: DomainEnrichmentJobStatus.PENDING,
-                    runAfter: new Date(),
-                    attempts: 0,
-                    lastError: null,
-                },
+            const pendingJob = await prisma.domainEnrichmentJob.update({
+                where: { id: job.id },
+                data: {status: DomainEnrichmentJobStatus.PENDING },
             });
 
             // Act
@@ -784,36 +735,31 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
     });
 
     describe('requeueDomainEnrichmentJob - Real Database Tests', () => {
-        let testDomainId: string;
+        // let testDomainId: string;
         let testJobId: string;
         const MAX_BACKOFF_MIN = 60; // Should match your constant
 
-        beforeAll(async () => {
-            // Create test domain
-            const domain = await prisma.domain.create({
-                data: {
-                    hostname: 'requeue-test.example.com',
-                },
-            });
-            testDomainId = domain.id;
-        });
+        // beforeAll(async () => {
+        //     // Create test domain
+        //     const domain = await prisma.domain.create({
+        //         data: {
+        //             hostname: 'requeue-test.example.com',
+        //         },
+        //     });
+        //     testDomainId = domain.id;
+        // });
 
-        afterAll(async () => {
-            // Clean up
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: { domainId: testDomainId },
-            });
-            await prisma.domain.delete({
-                where: { id: testDomainId },
-            });
-        });
+        // afterAll(async () => {
+        //     // Clean up
+        //     await prisma.domainEnrichmentJob.deleteMany({
+        //         where: { domainId: testDomainId },
+        //     });
+        //     await prisma.domain.delete({
+        //         where: { id: testDomainId },
+        //     });
+        // });
 
         beforeEach(async () => {
-            // Create a fresh job for each test
-            await prisma.domainEnrichmentJob.deleteMany({
-                where: { domainId: testDomainId },
-            });
-
             const job = await prisma.domainEnrichmentJob.create({
                 data: {
                     domainId: testDomainId,

--- a/tests/integration/dal/links/links.repo.test.ts
+++ b/tests/integration/dal/links/links.repo.test.ts
@@ -5,6 +5,7 @@ import { normalizeHostnameFromUrl } from '@/lib/utils';
 import { upsertDomainEnrichmentJob } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
 import { DomainEnrichmentJobStatus } from '@/generated/prisma/enums';
 import { InvalidHostnameError } from '@/lib/errors/InvalidHostnameError';
+import { resetDb } from '@/tests/helpers/db';
 
 vi.mock('@/lib/utils', () => ({
     normalizeHostnameFromUrl: vi.fn(),
@@ -14,11 +15,12 @@ vi.mock('@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo', () => ({
     upsertDomainEnrichmentJob: vi.fn(),
 }));
 
+beforeEach(async () => {
+    await resetDb();
+})
+
 describe('Link Repository - Integration Tests', () => {
     beforeEach(async () => {
-        await prisma.domainEnrichmentJob.deleteMany();
-        await prisma.link.deleteMany();
-        await prisma.domain.deleteMany();
         vi.clearAllMocks();
     });
 

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -15,5 +15,9 @@ export default defineConfig({
         globals: true,
         environment: 'node',
         include: ['tests/integration/**/*.test.ts'],
+        pool: 'forks',
+        fileParallelism: false,
+        maxConcurrency: 1,
+        sequence: { concurrent: false },
     },
 });


### PR DESCRIPTION
## Closes #78 
- Add condition for running integration tests on push to develop by specifying a given buzz-word (`[run-it]`)
- Remove duplication of gates between PRs on `feature/...` & `develop`
- Fix integration tests failure on CI
- Remove `feature/**` branches as a push trigger for the CI job