### PR TITLE
Provide minimal logging for the domain enrichment background worker

### DIFF
--- a/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.ts
+++ b/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.ts
@@ -1,9 +1,11 @@
 import {
-    ClaimedDomainJob, RequeueDomainEnrichmentJobInput,
+    ClaimedDomainJob,
+    RequeueDomainEnrichmentJobInput,
     UpsertDomainEnrichmentJobInput,
 } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.types';
 import { prisma } from '@/lib/prisma';
 import { DomainEnrichmentJobStatus } from '@/generated/prisma/enums';
+import { DomainEnrichmentJob } from '@/generated/prisma/client';
 
 const LEASE_MS = 2 * 60_000; // 2 minutes
 const STALE_GRACE_MS = 0;
@@ -91,23 +93,30 @@ export async function requeueDomainEnrichmentJob(input: RequeueDomainEnrichmentJ
     const backoffMinutes = computeBackoffMinutes(input.attempts);
     const nextRun = input.runAfter ?? new Date(Date.now() + backoffMinutes * 60_000);
 
-    await prisma.domainEnrichmentJob.update(
-        {
-            where: {
-                id: input.jobId
-            },
-            data: {
-                status: DomainEnrichmentJobStatus.PENDING,
-                runAfter: nextRun,
-                lockedUntil: null,
-                lastError: input.error instanceof Error ? input.error.message : String(input.error),
-            }
-        }
-    )
+    await prisma.domainEnrichmentJob.update({
+        where: {
+            id: input.jobId,
+        },
+        data: {
+            status: DomainEnrichmentJobStatus.PENDING,
+            runAfter: nextRun,
+            lockedUntil: null,
+            lastError: input.error instanceof Error ? input.error.message : String(input.error),
+        },
+    });
+}
+
+export async function getDomainEnrichmentJobById(id: string): Promise<DomainEnrichmentJob | null> {
+    return prisma.domainEnrichmentJob.findFirst({
+        where: { id },
+        include: {
+            domain: false,
+        },
+    });
 }
 
 function computeBackoffMinutes(attempts: number): number {
     const exp = Math.min(attempts, 10);
 
-    return Math.min(MAX_BACKOFF_MIN, Math.max(1, 2 **exp));
+    return Math.min(MAX_BACKOFF_MIN, Math.max(1, 2 ** exp));
 }

--- a/dal/domain_enrichment_jobs/domain_enrichment_jobs.service.ts
+++ b/dal/domain_enrichment_jobs/domain_enrichment_jobs.service.ts
@@ -1,7 +1,15 @@
 import { getRdapInfo, getWhoisInfo, pickBestKnown } from '@/dal/domains/domains.service';
 import { RdapDomainParams, RdapStatus } from '@/lib/rdap/rdap.types';
-import { updateDomainBestKnown, updateDomainRdapCache, updateDomainWhoisCache } from '@/dal/domains/domains.repo';
+import {
+    getDomainById,
+    updateDomainBestKnown,
+    updateDomainRdapCache,
+    updateDomainWhoisCache,
+} from '@/dal/domains/domains.repo';
 import { WhoisDomainParams } from '@/lib/whois/whois.types';
+import { DomainEnrichmentSummary } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.types';
+import { getDomainEnrichmentJobById } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
+import { logger } from '@/lib/logging/logger';
 
 export async function processDomainEnrichment(hostname: string, domainId: string): Promise<void> {
     const rdap: RdapDomainParams = await getRdapInfo(hostname);
@@ -36,4 +44,27 @@ export async function processDomainEnrichment(hostname: string, domainId: string
     if (best) {
         await updateDomainBestKnown({ domainId, ...best });
     }
+}
+
+export async function generateDomainEnrichmentJobSummary(jobId: string): Promise<DomainEnrichmentSummary | null> {
+    const job = await getDomainEnrichmentJobById(jobId);
+
+    if (!job) {
+        logger.warn(`Could not find domain enrichment job with ID=${jobId}`);
+        return null;
+    }
+
+    const domain = await getDomainById(job.domainId);
+
+    if (!domain) {
+        logger.warn(`Could not find domain with ID=${job.domainId}`);
+        return null;
+    }
+
+    return {
+        registeredAtFound: !!domain.registeredAt,
+        provider: domain.source,
+        domainStatus: domain.status,
+        jobStatus: job.status,
+    };
 }

--- a/dal/domain_enrichment_jobs/domain_enrichment_jobs.types.ts
+++ b/dal/domain_enrichment_jobs/domain_enrichment_jobs.types.ts
@@ -18,3 +18,10 @@ export type RequeueDomainEnrichmentJobInput = {
     error: Error | string;
     runAfter?: Date;
 };
+
+export type DomainEnrichmentSummary = {
+    registeredAtFound: boolean;
+    provider: 'RDAP' | 'WHOIS' | 'UNKNOWN';
+    domainStatus: string;
+    jobStatus: string;
+};

--- a/dal/domains/domains.repo.ts
+++ b/dal/domains/domains.repo.ts
@@ -1,5 +1,6 @@
 import {
-    CreateDomainInput, DomainProviderLocks,
+    CreateDomainInput,
+    DomainProviderLocks,
     UpdateDomainBestKnownInput,
     UpdateDomainRdapCacheInput,
     UpdateDomainWhoisCacheInput,
@@ -77,7 +78,6 @@ export async function updateDomainRdapCache(input: UpdateDomainRdapCacheInput): 
     });
 }
 
-
 export async function updateDomainWhoisCache(input: UpdateDomainWhoisCacheInput): Promise<void> {
     const now = new Date();
     const cooldown = computeWhoisFetchCooldown(now, input.status);
@@ -104,17 +104,22 @@ export async function updateDomainBestKnown(input: UpdateDomainBestKnownInput): 
     });
 }
 
-
 export async function getDomainProvidersLocks(domainId: string): Promise<DomainProviderLocks | null> {
     const locks = await prisma.domain.findUnique({
         where: { id: domainId },
         select: {
             rdapFetchLockedUntil: true,
             whoisFetchLockedUntil: true,
-        }
+        },
     });
 
     if (!locks || !locks.rdapFetchLockedUntil || !locks.whoisFetchLockedUntil) return null;
 
     return locks;
+}
+
+export async function getDomainById(domainId: string): Promise<Domain | null> {
+    return prisma.domain.findUnique({
+        where: { id: domainId },
+    });
 }

--- a/lib/logging/logger.types.ts
+++ b/lib/logging/logger.types.ts
@@ -6,3 +6,10 @@ export enum LogLevel {
 }
 
 export type LogMeta = Record<string, unknown>;
+
+export interface LoggerLike {
+    debug(msg: string, meta?: LogMeta): void;
+    info(msg: string, meta?: LogMeta): void;
+    warn(msg: string, meta?: LogMeta): void;
+    error(msg: string, meta?: LogMeta): void;
+}

--- a/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
+++ b/tests/integration/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo.test.ts
@@ -1,14 +1,15 @@
 import { describe, beforeEach, it, expect, afterAll, vi, afterEach } from 'vitest';
 import { prisma } from '@/lib/prisma';
-import { DomainEnrichmentJobStatus } from '@/generated/prisma/enums';
+import { DomainEnrichmentJobStatus, DomainSource, DomainStatus } from '@/generated/prisma/enums';
 import {
     claimNextDomainEnrichmentJob,
+    getDomainEnrichmentJobById,
     markDomainEnrichmentJobAsDone,
     requeueDomainEnrichmentJob,
     upsertDomainEnrichmentJob,
 } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
 import { resetDb } from '@/tests/helpers/db';
-import { DomainEnrichmentJob } from '@/generated/prisma/client';
+import { Domain, DomainEnrichmentJob } from '@/generated/prisma/client';
 
 const testDomainId = 'test-integration-domain-id';
 
@@ -131,9 +132,10 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
         });
     });
 
-    describe('Claim next domain enrichhment job', () => {
+    describe('Claim next domain enrichment job', () => {
         let testDomainId1: string;
         let testDomainId2: string;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         let testDomainId3: string;
 
         beforeEach(async () => {
@@ -704,30 +706,10 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
         });
     });
 
-    describe('requeueDomainEnrichmentJob - Real Database Tests', () => {
+    describe('Requeue domain enrichment job', () => {
         // let testDomainId: string;
         let testJobId: string;
         const MAX_BACKOFF_MIN = 60; // Should match your constant
-
-        // beforeAll(async () => {
-        //     // Create test domain
-        //     const domain = await prisma.domain.create({
-        //         data: {
-        //             hostname: 'requeue-test.example.com',
-        //         },
-        //     });
-        //     testDomainId = domain.id;
-        // });
-
-        // afterAll(async () => {
-        //     // Clean up
-        //     await prisma.domainEnrichmentJob.deleteMany({
-        //         where: { domainId: testDomainId },
-        //     });
-        //     await prisma.domain.delete({
-        //         where: { id: testDomainId },
-        //     });
-        // });
 
         beforeEach(async () => {
             const job = await prisma.domainEnrichmentJob.create({
@@ -1163,6 +1145,456 @@ describe('Domain Enrichment Jobs repository integration tests', () => {
 
                 vi.useRealTimers();
             });
+        });
+    });
+
+    describe('Domain enrichment job retrieval by ID', () => {
+        let testDomains: Domain[] = [];
+        let testJobs: DomainEnrichmentJob[] = [];
+
+        afterAll(async () => {
+            await resetDb();
+        });
+
+        beforeEach(async () => {
+            await resetDb();
+            await createTestData();
+        });
+
+        afterEach(async () => {
+            await resetDb();
+        });
+
+        async function createTestData() {
+            const domainPromises: Promise<Domain>[] = [
+                prisma.domain.create({
+                    data: {
+                        hostname: 'test-job-domain-1.example.com',
+                        source: DomainSource.UNKNOWN,
+                        status: DomainStatus.UNKNOWN,
+                        firstSeenAt: new Date('2024-01-15T10:00:00Z'),
+                    },
+                }),
+
+                prisma.domain.create({
+                    data: {
+                        hostname: 'test-job-domain-2.example.com',
+                        source: DomainSource.RDAP,
+                        status: DomainStatus.OK,
+                        firstSeenAt: new Date('2024-01-16T09:15:00Z'),
+                        registeredAt: new Date('2020-01-01T00:00:00Z'),
+                    },
+                }),
+
+                prisma.domain.create({
+                    data: {
+                        hostname: 'test-job-domain-3.example.com',
+                        source: DomainSource.WHOIS,
+                        status: DomainStatus.OK,
+                        firstSeenAt: new Date('2024-01-17T14:20:00Z'),
+                        registeredAt: new Date('2019-05-10T00:00:00Z'),
+                        whoisRaw: 'Domain successfully enriched',
+                        whoisFetchedAt: new Date('2024-01-20T11:30:00Z'),
+                    },
+                }),
+
+                prisma.domain.create({
+                    data: {
+                        hostname: 'test-job-domain-4.example.com',
+                        source: DomainSource.UNKNOWN,
+                        status: DomainStatus.ERROR,
+                        firstSeenAt: new Date('2024-01-18T11:30:00Z'),
+                    },
+                }),
+
+                prisma.domain.create({
+                    data: {
+                        hostname: 'test-job-domain-5.example.com',
+                        source: DomainSource.UNKNOWN,
+                        status: DomainStatus.UNKNOWN,
+                        firstSeenAt: new Date('2024-01-19T13:25:00Z'),
+                    },
+                }),
+
+                prisma.domain.create({
+                    data: {
+                        hostname: 'test-job-domain-6.example.com',
+                        source: DomainSource.UNKNOWN,
+                        status: DomainStatus.UNKNOWN,
+                        firstSeenAt: new Date('2024-01-20T16:45:00Z'),
+                    },
+                }),
+            ];
+
+            testDomains = await Promise.all(domainPromises);
+
+            testJobs = await Promise.all([
+                prisma.domainEnrichmentJob.create({
+                    data: {
+                        domainId: testDomains[0].id,
+                        status: DomainEnrichmentJobStatus.PENDING,
+                        runAfter: new Date('2024-01-25T10:00:00Z'),
+                        attempts: 0,
+                        lastError: null,
+                        lockedUntil: null,
+                    },
+                    include: {
+                        domain: true,
+                    },
+                }),
+
+                // Job RUNNING cu lock
+                prisma.domainEnrichmentJob.create({
+                    data: {
+                        domainId: testDomains[1].id,
+                        status: DomainEnrichmentJobStatus.RUNNING,
+                        runAfter: new Date('2024-01-20T09:00:00Z'),
+                        attempts: 1,
+                        lastError: null,
+                        lockedUntil: new Date(Date.now() + 3600000), // +1 hour
+                    },
+                    include: {
+                        domain: true,
+                    },
+                }),
+
+                prisma.domainEnrichmentJob.create({
+                    data: {
+                        domainId: testDomains[2].id,
+                        status: DomainEnrichmentJobStatus.DONE,
+                        runAfter: new Date('2024-01-19T14:00:00Z'),
+                        attempts: 1,
+                        lastError: null,
+                        lockedUntil: null,
+                    },
+                    include: {
+                        domain: true,
+                    },
+                }),
+
+                prisma.domainEnrichmentJob.create({
+                    data: {
+                        domainId: testDomains[3].id,
+                        status: DomainEnrichmentJobStatus.ERROR,
+                        runAfter: new Date('2024-01-22T16:00:00Z'),
+                        attempts: 3,
+                        lastError: 'Failed to fetch RDAP data: Connection timeout',
+                        lockedUntil: null,
+                    },
+                    include: {
+                        domain: true,
+                    },
+                }),
+
+                prisma.domainEnrichmentJob.create({
+                    data: {
+                        domainId: testDomains[4].id,
+                        status: DomainEnrichmentJobStatus.PENDING,
+                        runAfter: new Date('2024-01-23T08:00:00Z'),
+                        attempts: 0,
+                        lastError: null,
+                        lockedUntil: new Date(Date.now() + 1800000), // +30 minutes
+                    },
+                    include: {
+                        domain: true,
+                    },
+                }),
+
+                prisma.domainEnrichmentJob.create({
+                    data: {
+                        domainId: testDomains[5].id,
+                        status: DomainEnrichmentJobStatus.PENDING,
+                        runAfter: new Date('2024-01-21T12:00:00Z'),
+                        attempts: 5,
+                        lastError: 'Multiple failures occurred',
+                        lockedUntil: new Date(Date.now() - 3600000), // -1 hour
+                    },
+                    include: {
+                        domain: true,
+                    },
+                }),
+            ]);
+        }
+
+        it('Should retrieve a PENDING job by ID with all fields', async () => {
+            const pendingJob = testJobs[0];
+
+            const result = await getDomainEnrichmentJobById(pendingJob.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(pendingJob.id);
+            expect(result?.domainId).toBe(testDomains[0].id);
+            expect(result?.status).toBe(DomainEnrichmentJobStatus.PENDING);
+            expect(result?.attempts).toBe(0);
+            expect(result?.lastError).toBeNull();
+            expect(result?.lockedUntil).toBeNull();
+
+            expect(result?.runAfter).toBeInstanceOf(Date);
+            expect(result?.createdAt).toBeInstanceOf(Date);
+            expect(result?.updatedAt).toBeInstanceOf(Date);
+        });
+
+        it('Should retrieve a RUNNING job with lock', async () => {
+            const runningJob = testJobs[1];
+
+            const result = await getDomainEnrichmentJobById(runningJob.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(runningJob.id);
+            expect(result?.status).toBe(DomainEnrichmentJobStatus.RUNNING);
+            expect(result?.attempts).toBe(1);
+            expect(result?.lastError).toBeNull();
+            expect(result?.lockedUntil).toBeInstanceOf(Date);
+            expect(result?.lockedUntil!.getTime()).toBeGreaterThan(Date.now());
+        });
+
+        it('Should retrieve a DONE job (completed successfully)', async () => {
+            const doneJob = testJobs[2];
+
+            const result = await getDomainEnrichmentJobById(doneJob.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(doneJob.id);
+            expect(result?.status).toBe(DomainEnrichmentJobStatus.DONE);
+            expect(result?.attempts).toBe(1);
+            expect(result?.lastError).toBeNull();
+            expect(result?.lockedUntil).toBeNull();
+            expect(result?.runAfter.getTime()).toBeLessThanOrEqual(Date.now());
+        });
+
+        it('Should retrieve an ERROR job with error message', async () => {
+            const errorJob = testJobs[3];
+
+            const result = await getDomainEnrichmentJobById(errorJob.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(errorJob.id);
+            expect(result?.status).toBe(DomainEnrichmentJobStatus.ERROR);
+            expect(result?.attempts).toBe(3);
+            expect(result?.lastError).toBe('Failed to fetch RDAP data: Connection timeout');
+            expect(result?.lockedUntil).toBeNull();
+        });
+
+        it('Should retrieve a PENDING job with future lock', async () => {
+            const pendingLockedJob = testJobs[4];
+
+            const result = await getDomainEnrichmentJobById(pendingLockedJob.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(pendingLockedJob.id);
+            expect(result?.status).toBe(DomainEnrichmentJobStatus.PENDING);
+            expect(result?.lockedUntil).toBeInstanceOf(Date);
+            expect(result?.lockedUntil!.getTime()).toBeGreaterThan(Date.now());
+            expect(result?.attempts).toBe(0);
+            expect(result?.lastError).toBeNull();
+        });
+
+        it('Should retrieve a job with expired lock and multiple attempts', async () => {
+            const expiredLockJob = testJobs[5];
+
+            const result = await getDomainEnrichmentJobById(expiredLockJob.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(expiredLockJob.id);
+            expect(result?.status).toBe(DomainEnrichmentJobStatus.PENDING);
+            expect(result?.attempts).toBe(5);
+            expect(result?.lastError).toBe('Multiple failures occurred');
+            expect(result?.lockedUntil).toBeInstanceOf(Date);
+            expect(result?.lockedUntil!.getTime()).toBeLessThan(Date.now());
+        });
+
+        it('Should return null for non-existent job ID', async () => {
+            const nonExistentId = 'non-existent-id-1234567890abcdef';
+
+            const result = await getDomainEnrichmentJobById(nonExistentId);
+
+            expect(result).toBeNull();
+        });
+
+        it('Should handle empty string ID', async () => {
+            const result = await getDomainEnrichmentJobById('');
+
+            expect(result).toBeNull();
+        });
+
+        it('Should handle invalid ID format', async () => {
+            const invalidId = 'not-a-valid-uuid-or-cuid';
+
+            const result = await getDomainEnrichmentJobById(invalidId);
+
+            expect(result).toBeNull();
+        });
+
+        it('Should maintain data integrity for retrieved job', async () => {
+            const testJob = testJobs[2]; // DONE job
+
+            const result = await getDomainEnrichmentJobById(testJob.id);
+
+            expect(result?.id).toBe(testJob.id);
+            expect(result?.domainId).toBe(testJob.domainId);
+            expect(result?.status).toBe(testJob.status);
+            expect(result?.attempts).toBe(testJob.attempts);
+            expect(result?.lastError).toBe(testJob.lastError);
+
+            expect(result?.runAfter.toISOString()).toBe(testJob.runAfter.toISOString());
+            if (result?.lockedUntil && testJob.lockedUntil) {
+                expect(result.lockedUntil.toISOString()).toBe(testJob.lockedUntil.toISOString());
+            } else {
+                expect(result?.lockedUntil).toBe(testJob.lockedUntil);
+            }
+        });
+
+        it('Should handle all DomainEnrichmentJobStatus enum values', async () => {
+            const statusJobs = testJobs.reduce(
+                (acc, job) => {
+                    acc[job.status] = job;
+                    return acc;
+                },
+                {} as Record<DomainEnrichmentJobStatus, DomainEnrichmentJob>
+            );
+
+            const pendingResult = await getDomainEnrichmentJobById(statusJobs.PENDING.id);
+            expect(pendingResult?.status).toBe(DomainEnrichmentJobStatus.PENDING);
+
+            const runningResult = await getDomainEnrichmentJobById(statusJobs.RUNNING.id);
+            expect(runningResult?.status).toBe(DomainEnrichmentJobStatus.RUNNING);
+
+            const doneResult = await getDomainEnrichmentJobById(statusJobs.DONE.id);
+            expect(doneResult?.status).toBe(DomainEnrichmentJobStatus.DONE);
+
+            const errorResult = await getDomainEnrichmentJobById(statusJobs.ERROR.id);
+            expect(errorResult?.status).toBe(DomainEnrichmentJobStatus.ERROR);
+        });
+
+        it('Should handle jobs with very long error messages', async () => {
+            const longErrorDomain = await prisma.domain.create({
+                data: {
+                    hostname: 'test-long-error.example.com',
+                    source: DomainSource.UNKNOWN,
+                    status: DomainStatus.UNKNOWN,
+                    firstSeenAt: new Date(),
+                },
+            });
+
+            const longErrorMessage =
+                'Error: '.repeat(100) +
+                'Failed after multiple attempts. Details: ' +
+                JSON.stringify({
+                    code: 'TIMEOUT',
+                    url: 'https://rdap.example.com/long/path/to/resource',
+                    attempts: 10,
+                });
+
+            const longErrorJob = await prisma.domainEnrichmentJob.create({
+                data: {
+                    domainId: longErrorDomain.id,
+                    status: DomainEnrichmentJobStatus.ERROR,
+                    runAfter: new Date(),
+                    attempts: 10,
+                    lastError: longErrorMessage,
+                    lockedUntil: null,
+                },
+            });
+
+            try {
+                const result = await getDomainEnrichmentJobById(longErrorJob.id);
+
+                expect(result).not.toBeNull();
+                expect(result?.status).toBe(DomainEnrichmentJobStatus.ERROR);
+                expect(result?.attempts).toBe(10);
+                expect(result?.lastError).toBe(longErrorMessage);
+                expect(result?.lastError?.length).toBe(longErrorMessage.length);
+            } finally {
+                // Cleanup
+                await prisma.domainEnrichmentJob.delete({
+                    where: { id: longErrorJob.id },
+                });
+                await prisma.domain.delete({
+                    where: { id: longErrorDomain.id },
+                });
+            }
+        });
+
+        it('Should handle jobs with future runAfter dates', async () => {
+            const futureDomain = await prisma.domain.create({
+                data: {
+                    hostname: 'test-future-run.example.com',
+                    source: DomainSource.UNKNOWN,
+                    status: DomainStatus.UNKNOWN,
+                    firstSeenAt: new Date(),
+                },
+            });
+
+            const futureDate = new Date(Date.now() + 86400000); // +1 day
+
+            const futureJob = await prisma.domainEnrichmentJob.create({
+                data: {
+                    domainId: futureDomain.id,
+                    status: DomainEnrichmentJobStatus.PENDING,
+                    runAfter: futureDate,
+                    attempts: 0,
+                    lastError: null,
+                    lockedUntil: null,
+                },
+            });
+
+            try {
+                const result = await getDomainEnrichmentJobById(futureJob.id);
+
+                expect(result).not.toBeNull();
+                expect(result?.runAfter.getTime()).toBe(futureDate.getTime());
+                expect(result?.runAfter.getTime()).toBeGreaterThan(Date.now());
+            } finally {
+                await prisma.domainEnrichmentJob.delete({
+                    where: { id: futureJob.id },
+                });
+                await prisma.domain.delete({
+                    where: { id: futureDomain.id },
+                });
+            }
+        });
+
+        it('Should handle concurrent requests for different jobs', async () => {
+            const promises = testJobs.map((job) => getDomainEnrichmentJobById(job.id));
+
+            const results = await Promise.all(promises);
+
+            results.forEach((result, index) => {
+                expect(result).not.toBeNull();
+                expect(result?.id).toBe(testJobs[index].id);
+                expect(result?.domainId).toBe(testJobs[index].domainId);
+                expect(result?.status).toBe(testJobs[index].status);
+
+                expect(Object.values(DomainEnrichmentJobStatus)).toContain(result?.status);
+            });
+        });
+
+        it('Should handle job with domain relation constraints', async () => {
+            const testJob = testJobs[0];
+
+            const result = await getDomainEnrichmentJobById(testJob.id);
+
+            expect(result).not.toBeNull();
+            expect(testDomains.map((d) => d.id)).toContain(result?.domainId);
+
+            const associatedDomain = await prisma.domain.findUnique({
+                where: { id: result!.domainId },
+            });
+
+            expect(associatedDomain).not.toBeNull();
+            expect(associatedDomain?.id).toBe(result?.domainId);
+        });
+
+        it('Should not include domain relation by default', async () => {
+            const testJob = testJobs[0];
+            const result = await getDomainEnrichmentJobById(testJob.id);
+
+            expect(result).not.toBeNull();
+            expect(result).toHaveProperty('id');
+            expect(result).toHaveProperty('domainId');
+            expect(result).toHaveProperty('status');
+            expect(result).toHaveProperty('runAfter');
+            expect(result).toHaveProperty('attempts');
         });
     });
 });

--- a/tests/integration/dal/domains/domains.repo.test.ts
+++ b/tests/integration/dal/domains/domains.repo.test.ts
@@ -1,8 +1,9 @@
-import { afterAll, beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { prisma } from '@/lib/prisma';
 import { createLink } from '@/dal/links/links.repo';
 import { normalizeHostnameFromUrl } from '@/lib/utils';
 import {
+    getDomainById,
     getDomainProvidersLocks,
     updateDomainBestKnown,
     updateDomainRdap,
@@ -12,6 +13,8 @@ import {
 import { DomainSource, DomainStatus } from '@/generated/prisma/enums';
 import { RdapDomainParams, RdapStatus } from '@/lib/rdap/rdap.types';
 import { WhoisStatus } from '@/lib/whois/whois.types';
+import { Domain } from '@/generated/prisma/client';
+import { resetDb } from '@/tests/helpers/db';
 
 const mockedUtils = vi.hoisted(() => ({
     normalizeHostnameFromUrl: vi.fn(),
@@ -83,6 +86,435 @@ describe('Domain repo integration tests', () => {
             where: { hostname: mockHostname },
         });
         expect(updatedDomain?.firstSeenAt).toEqual(initialFirstSeen);
+    });
+
+    describe('Domain retrieval by ID - integration tests', () => {
+        let testDomains: Domain[] = [];
+
+        beforeAll(async () => {
+            await resetDb();
+        });
+
+        afterAll(async () => {
+            await resetDb();
+        });
+
+        beforeEach(async () => {
+            testDomains = await createTestDomains();
+        });
+
+        afterEach(async () => {
+            await resetDb();
+        });
+
+        async function createTestDomains(): Promise<Domain[]> {
+            return [
+                // Domain cu RDAP
+                await prisma.domain.create({
+                    data: {
+                        hostname: 'test-getbyid-rdap.example.com',
+                        source: DomainSource.RDAP,
+                        status: DomainStatus.OK,
+                        firstSeenAt: new Date('2024-01-15T10:00:00Z'),
+                        registeredAt: new Date('2020-05-20T00:00:00Z'),
+                        checkedAt: new Date('2024-01-20T14:30:00Z'),
+                        rdapRaw: {
+                            events: [
+                                {
+                                    eventAction: 'registration',
+                                    eventDate: '2020-05-20T00:00:00Z',
+                                },
+                            ],
+                            entities: [
+                                {
+                                    roles: ['registrant'],
+                                    vcardArray: ['vcard', [{ fn: 'Test Company' }]],
+                                },
+                            ],
+                        },
+                        rdapFetchedAt: new Date('2024-01-20T14:30:00Z'),
+                        whoisRaw: null,
+                        whoisFetchedAt: null,
+                        rdapFetchLockedUntil: null,
+                        whoisFetchLockedUntil: null,
+                    },
+                }),
+
+                // Domain cu WHOIS
+                await prisma.domain.create({
+                    data: {
+                        hostname: 'test-getbyid-whois.example.com',
+                        source: DomainSource.WHOIS,
+                        status: DomainStatus.OK,
+                        firstSeenAt: new Date('2024-01-16T09:15:00Z'),
+                        registeredAt: new Date('2019-11-10T00:00:00Z'),
+                        checkedAt: new Date('2024-01-21T11:45:00Z'),
+                        rdapFetchedAt: null,
+                        whoisRaw: `Domain Name: test-getbyid-whois.example.com
+Registry Domain ID: 1234567890_EXAMPLE_COM-VRSN
+Registrar WHOIS Server: whois.example.com
+Updated Date: 2023-12-01T00:00:00Z
+Creation Date: 2019-11-10T00:00:00Z
+Registrar Registration Expiration Date: 2025-11-10T00:00:00Z
+Registrar: Example Registrar Inc.
+Domain Status: clientTransferProhibited`,
+                        whoisFetchedAt: new Date('2024-01-21T11:45:00Z'),
+                        rdapFetchLockedUntil: null,
+                        whoisFetchLockedUntil: null,
+                    },
+                }),
+
+                // Domain cu status UNKNOWN
+                await prisma.domain.create({
+                    data: {
+                        hostname: 'test-getbyid-unknown.example.com',
+                        source: DomainSource.UNKNOWN,
+                        status: DomainStatus.UNKNOWN,
+                        firstSeenAt: new Date('2024-01-17T14:20:00Z'),
+                        registeredAt: null,
+                        checkedAt: null,
+                        rdapFetchedAt: null,
+                        whoisRaw: null,
+                        whoisFetchedAt: null,
+                        rdapFetchLockedUntil: null,
+                        whoisFetchLockedUntil: null,
+                    },
+                }),
+
+                await prisma.domain.create({
+                    data: {
+                        hostname: 'test-getbyid-status-ok.example.com',
+                        source: DomainSource.RDAP,
+                        status: DomainStatus.OK,
+                        firstSeenAt: new Date('2024-01-18T08:45:00Z'),
+                        registeredAt: new Date('2021-03-15T00:00:00Z'),
+                        checkedAt: new Date('2024-01-22T16:20:00Z'),
+                        rdapRaw: { test: 'data' },
+                        rdapFetchedAt: new Date('2024-01-22T16:20:00Z'),
+                        whoisRaw: null,
+                        whoisFetchedAt: null,
+                    },
+                }),
+
+                await prisma.domain.create({
+                    data: {
+                        hostname: 'test-getbyid-status-missing.example.com',
+                        source: DomainSource.WHOIS,
+                        status: DomainStatus.MISSING,
+                        firstSeenAt: new Date('2024-01-19T11:30:00Z'),
+                        registeredAt: null,
+                        checkedAt: new Date('2024-01-23T09:10:00Z'),
+                        rdapFetchedAt: null,
+                        whoisRaw: 'Domain not found in registry',
+                        whoisFetchedAt: new Date('2024-01-23T09:10:00Z'),
+                    },
+                }),
+
+                // Domain cu locks
+                await prisma.domain.create({
+                    data: {
+                        hostname: 'test-getbyid-with-locks.example.com',
+                        source: DomainSource.UNKNOWN,
+                        status: DomainStatus.UNKNOWN,
+                        firstSeenAt: new Date('2024-01-20T13:25:00Z'),
+                        rdapFetchLockedUntil: new Date(Date.now() + 3600000), // +1 hour
+                        whoisFetchLockedUntil: new Date(Date.now() + 1800000), // +30 minutes
+                    },
+                }),
+
+                await prisma.domain.create({
+                    data: {
+                        hostname: 'test-getbyid-complete.example.com',
+                        source: DomainSource.RDAP,
+                        status: DomainStatus.OK,
+                        firstSeenAt: new Date('2024-01-01T00:00:00Z'),
+                        registeredAt: new Date('2018-08-01T00:00:00Z'),
+                        checkedAt: new Date('2024-01-25T10:00:00Z'),
+                        rdapRaw: {
+                            handle: 'ABC123',
+                            name: 'Complete Domain',
+                            events: [
+                                { eventAction: 'registration', eventDate: '2018-08-01T00:00:00Z' },
+                                { eventAction: 'last changed', eventDate: '2023-12-01T00:00:00Z' },
+                            ],
+                        },
+                        rdapFetchedAt: new Date('2024-01-25T10:00:00Z'),
+                        whoisRaw: 'Domain name: complete.example.com\nStatus: active',
+                        whoisFetchedAt: new Date('2024-01-24T15:30:00Z'),
+                        rdapFetchLockedUntil: null,
+                        whoisFetchLockedUntil: new Date(Date.now() + 7200000), // +2 hours
+                    },
+                }),
+            ];
+        }
+
+        it('should retrieve a domain by ID with RDAP source', async () => {
+            const rdapDomain = testDomains[0];
+
+            const result = await getDomainById(rdapDomain.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(rdapDomain.id);
+            expect(result?.hostname).toBe('test-getbyid-rdap.example.com');
+            expect(result?.source).toBe(DomainSource.RDAP);
+            expect(result?.status).toBe(DomainStatus.OK);
+            expect(result?.rdapRaw).toBeDefined();
+            expect(result?.rdapRaw).toHaveProperty('events');
+            expect(result?.rdapFetchedAt).toBeInstanceOf(Date);
+            expect(result?.whoisRaw).toBeNull();
+            expect(result?.firstSeenAt).toBeInstanceOf(Date);
+            expect(result?.registeredAt).toBeInstanceOf(Date);
+            expect(result?.checkedAt).toBeInstanceOf(Date);
+        });
+
+        it('should retrieve a domain by ID with WHOIS source', async () => {
+            const whoisDomain = testDomains[1];
+
+            const result = await getDomainById(whoisDomain.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(whoisDomain.id);
+            expect(result?.hostname).toBe('test-getbyid-whois.example.com');
+            expect(result?.source).toBe(DomainSource.WHOIS);
+            expect(result?.status).toBe(DomainStatus.OK);
+            expect(result?.whoisRaw).toContain('test-getbyid-whois.example.com');
+            expect(result?.whoisFetchedAt).toBeInstanceOf(Date);
+            expect(result?.rdapRaw).toBeNull();
+            expect(result?.rdapFetchedAt).toBeNull();
+            expect(result?.registeredAt).toBeInstanceOf(Date);
+        });
+
+        it('should retrieve a domain by ID with UNKNOWN source and status', async () => {
+            const unknownDomain = testDomains[2];
+
+            const result = await getDomainById(unknownDomain.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.id).toBe(unknownDomain.id);
+            expect(result?.hostname).toBe('test-getbyid-unknown.example.com');
+            expect(result?.source).toBe(DomainSource.UNKNOWN);
+            expect(result?.status).toBe(DomainStatus.UNKNOWN);
+            expect(result?.rdapRaw).toBeNull();
+            expect(result?.whoisRaw).toBeNull();
+            expect(result?.registeredAt).toBeNull();
+            expect(result?.checkedAt).toBeNull();
+            expect(result?.firstSeenAt).toBeInstanceOf(Date);
+        });
+
+        it('should handle all DomainStatus enum values correctly', async () => {
+            const okDomain = testDomains[3];
+            const missingDomain = testDomains[4];
+
+            // Test pentru OK status
+            const okResult = await getDomainById(okDomain.id);
+            expect(okResult?.status).toBe(DomainStatus.OK);
+            expect(okResult?.source).toBe(DomainSource.RDAP);
+
+            // Test pentru MISSING status
+            const missingResult = await getDomainById(missingDomain.id);
+            expect(missingResult?.status).toBe(DomainStatus.MISSING);
+            expect(missingResult?.source).toBe(DomainSource.WHOIS);
+            expect(missingResult?.whoisRaw).toBe('Domain not found in registry');
+        });
+
+        it('should retrieve domain with fetch locks', async () => {
+            const lockedDomain = testDomains[5];
+
+            const result = await getDomainById(lockedDomain.id);
+
+            expect(result).not.toBeNull();
+            expect(result?.rdapFetchLockedUntil).toBeInstanceOf(Date);
+            expect(result?.whoisFetchLockedUntil).toBeInstanceOf(Date);
+
+            // Verifică că lock-urile sunt în viitor
+            expect(result?.rdapFetchLockedUntil!.getTime()).toBeGreaterThan(Date.now());
+            expect(result?.whoisFetchLockedUntil!.getTime()).toBeGreaterThan(Date.now());
+        });
+
+        it('should retrieve complete domain with all fields populated', async () => {
+            const completeDomain = testDomains[6];
+
+            const result = await getDomainById(completeDomain.id);
+
+            expect(result).not.toBeNull();
+
+            expect(result?.hostname).toBe('test-getbyid-complete.example.com');
+            expect(result?.source).toBe(DomainSource.RDAP);
+            expect(result?.status).toBe(DomainStatus.OK);
+
+            expect(result?.firstSeenAt).toBeInstanceOf(Date);
+            expect(result?.registeredAt).toBeInstanceOf(Date);
+            expect(result?.checkedAt).toBeInstanceOf(Date);
+            expect(result?.createdAt).toBeInstanceOf(Date);
+            expect(result?.updatedAt).toBeInstanceOf(Date);
+
+            expect(result?.rdapRaw).toBeDefined();
+            expect(result?.rdapRaw).not.toBeNull();
+
+            if (
+                result?.rdapRaw &&
+                typeof result.rdapRaw === 'object' &&
+                !Array.isArray(result.rdapRaw)
+            ) {
+                const rdapRaw = result.rdapRaw as {
+                    handle?: string;
+                    name?: string;
+                    events?: unknown[];
+                };
+
+                expect(rdapRaw.handle).toBe('ABC123');
+                expect(rdapRaw.name).toBe('Complete Domain');
+                expect(rdapRaw.events).toBeDefined();
+                expect(Array.isArray(rdapRaw.events)).toBe(true);
+                expect(rdapRaw.events?.length).toBe(2);
+            } else {
+                // Dacă nu e un obiect, testul ar trebui să eșueze
+                expect(result?.rdapRaw).toBeInstanceOf(Object);
+            }
+
+            expect(result?.rdapFetchedAt).toBeInstanceOf(Date);
+
+            expect(result?.whoisRaw).toContain('complete.example.com');
+            expect(result?.whoisFetchedAt).toBeInstanceOf(Date);
+
+            expect(result?.rdapFetchLockedUntil).toBeNull();
+            expect(result?.whoisFetchLockedUntil).toBeInstanceOf(Date);
+            expect(result?.whoisFetchLockedUntil!.getTime()).toBeGreaterThan(Date.now());
+        });
+
+        it('should return null for non-existent domain ID', async () => {
+            const nonExistentId = 'non-existent-id-1234567890abcdef';
+
+            const result = await getDomainById(nonExistentId);
+
+            expect(result).toBeNull();
+        });
+
+        it('should handle empty string ID', async () => {
+            const result = await getDomainById('');
+
+            expect(result).toBeNull();
+        });
+
+        it('should handle invalid ID format', async () => {
+            const invalidId = 'not-a-valid-uuid-or-cuid';
+
+            const result = await getDomainById(invalidId);
+
+            expect(result).toBeNull();
+        });
+
+        it('should maintain data integrity for all retrieved fields', async () => {
+            const completeDomain = testDomains[6];
+
+            const result = await getDomainById(completeDomain.id);
+
+            // Verifică că datele sunt identice cu cele inserate
+            expect(result?.hostname).toBe(completeDomain.hostname);
+            expect(result?.source).toBe(completeDomain.source);
+            expect(result?.status).toBe(completeDomain.status);
+
+            // Verifică datele exacte
+            expect(result?.firstSeenAt?.toISOString()).toBe(completeDomain.firstSeenAt.toISOString());
+            expect(result?.registeredAt?.toISOString()).toBe(completeDomain.registeredAt?.toISOString());
+            expect(result?.checkedAt?.toISOString()).toBe(completeDomain.checkedAt?.toISOString());
+
+            // Verifică JSON fields
+            expect(JSON.stringify(result?.rdapRaw)).toBe(JSON.stringify(completeDomain.rdapRaw));
+            expect(result?.whoisRaw).toBe(completeDomain.whoisRaw);
+        });
+
+        it('should correctly handle domains with REDACTED and ERROR status', async () => {
+            // Crează domain suplimentar pentru REDACTED status
+            const redactedDomain = await prisma.domain.create({
+                data: {
+                    hostname: 'test-redacted-status.example.com',
+                    source: DomainSource.RDAP,
+                    status: DomainStatus.REDACTED,
+                    firstSeenAt: new Date(),
+                    rdapRaw: {
+                        remarks: [{ title: 'Data redacted for privacy' }],
+                    },
+                    rdapFetchedAt: new Date(),
+                },
+            });
+
+            // Crează domain suplimentar pentru ERROR status
+            const errorDomain = await prisma.domain.create({
+                data: {
+                    hostname: 'test-error-status.example.com',
+                    source: DomainSource.WHOIS,
+                    status: DomainStatus.ERROR,
+                    firstSeenAt: new Date(),
+                    whoisRaw: 'ERROR: Connection failed',
+                    whoisFetchedAt: new Date(),
+                },
+            });
+
+            try {
+                // Test REDACTED status
+                const redactedResult = await getDomainById(redactedDomain.id);
+                expect(redactedResult?.status).toBe(DomainStatus.REDACTED);
+                expect(redactedResult?.source).toBe(DomainSource.RDAP);
+                expect(redactedResult?.rdapRaw).toHaveProperty('remarks');
+
+                // Test ERROR status
+                const errorResult = await getDomainById(errorDomain.id);
+                expect(errorResult?.status).toBe(DomainStatus.ERROR);
+                expect(errorResult?.source).toBe(DomainSource.WHOIS);
+                expect(errorResult?.whoisRaw).toContain('ERROR');
+            } finally {
+                // Cleanup domain-urile adiționale
+                await prisma.domain.deleteMany({
+                    where: {
+                        id: {
+                            in: [redactedDomain.id, errorDomain.id],
+                        },
+                    },
+                });
+            }
+        });
+
+        it('should handle UNSUPPORTED domain status', async () => {
+            const unsupportedDomain = await prisma.domain.create({
+                data: {
+                    hostname: 'test-unsupported.example.com',
+                    source: DomainSource.UNKNOWN,
+                    status: DomainStatus.UNSUPPORTED,
+                    firstSeenAt: new Date(),
+                    rdapRaw: { error: 'TLD not supported' },
+                    rdapFetchedAt: new Date(),
+                },
+            });
+
+            try {
+                const result = await getDomainById(unsupportedDomain.id);
+
+                expect(result?.status).toBe(DomainStatus.UNSUPPORTED);
+                expect(result?.source).toBe(DomainSource.UNKNOWN);
+                expect(result?.rdapRaw).toHaveProperty('error', 'TLD not supported');
+            } finally {
+                await prisma.domain.delete({
+                    where: { id: unsupportedDomain.id },
+                });
+            }
+        });
+
+        it('should handle concurrent requests for different domains', async () => {
+            // Face request-uri simultane pentru toate domain-urile
+            const promises = testDomains.map((domain) => getDomainById(domain.id));
+
+            const results = await Promise.all(promises);
+
+            results.forEach((result, index) => {
+                expect(result).not.toBeNull();
+                expect(result?.id).toBe(testDomains[index].id);
+                expect(result?.hostname).toBe(testDomains[index].hostname);
+
+                expect(Object.values(DomainSource)).toContain(result?.source);
+                expect(Object.values(DomainStatus)).toContain(result?.status);
+            });
+        });
     });
 });
 

--- a/tests/unit/dal/domains_enrichment_jobs/domains_enrichment_jobs_service.test.ts
+++ b/tests/unit/dal/domains_enrichment_jobs/domains_enrichment_jobs_service.test.ts
@@ -1,10 +1,15 @@
 import { describe, it, beforeEach, afterEach, expect, vi, Mock } from 'vitest';
-import { DomainSource, DomainStatus } from '@/generated/prisma/enums';
+import { DomainEnrichmentJobStatus, DomainSource, DomainStatus } from '@/generated/prisma/enums';
 import { RdapDomainParams, RdapStatus } from '@/lib/rdap/rdap.types';
 import { WhoisDomainParams, WhoisStatus } from '@/lib/whois/whois.types';
 import { pickBestKnown } from '@/dal/domains/domains.service';
 import { mapStatusToDomainStatus } from '@/dal/domains/domains.mapper';
 import { getStatusPriority } from '@/lib/domain_enrichment_job/priority';
+import { getDomainEnrichmentJobById } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
+import { getDomainById } from '@/dal/domains/domains.repo';
+import { logger } from '@/lib/logging/logger';
+import { generateDomainEnrichmentJobSummary } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.service';
+import { Domain, DomainEnrichmentJob } from '@/generated/prisma/client';
 
 // Mock the dependencies
 vi.mock('@/lib/domain_enrichment_job/priority', () => ({
@@ -15,384 +20,867 @@ vi.mock('@/dal/domains/domains.mapper', () => ({
     mapStatusToDomainStatus: vi.fn(),
 }));
 
-describe('pickBestKnown', () => {
-    const mockDate = new Date('2024-01-15T10:30:00Z');
-    const mockRegisteredDate = new Date('2023-01-01T00:00:00Z');
+vi.mock('@/dal/domains/domains.repo', () => ({
+    getDomainById: vi.fn(),
+}));
 
-    beforeEach(() => {
-        vi.clearAllMocks();
-        vi.useFakeTimers();
-        vi.setSystemTime(mockDate);
-    });
+vi.mock('@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo', () => ({
+    getDomainEnrichmentJobById: vi.fn(),
+}));
 
-    afterEach(() => {
-        vi.useRealTimers();
-    });
+vi.mock('@/lib/logging/logger', () => ({
+    logger: {
+        warn: vi.fn(),
+    },
+}));
 
-    describe('RDAP has registration date', () => {
-        it('should prefer RDAP when RDAP has registeredAt date', () => {
-            // Arrange
-            const rdap = {
-                registeredAt: mockRegisteredDate,
-                status: RdapStatus.OK,
-                checkedAt: mockDate,
-                source: 'RDAP' as const,
-            };
+const mockGetDomainEnrichmentJobById = vi.mocked(getDomainEnrichmentJobById);
+const mockGetDomainById = vi.mocked(getDomainById);
+const mockLoggerWarn = logger.warn;
 
-            const whois = {
-                registeredAt: mockRegisteredDate,
-                status: WhoisStatus.OK,
-                checkedAt: new Date('2024-01-15T09:30:00Z'), // Earlier check
-            };
 
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+describe('Domain Enrichment Jobs service tests', () => {
+    describe('Pick best known tests', () => {
+        const mockDate = new Date('2024-01-15T10:30:00Z');
+        const mockRegisteredDate = new Date('2023-01-01T00:00:00Z');
 
-            // Act
-            const result = pickBestKnown(rdap, whois);
-
-            // Assert
-            expect(result).toEqual({
-                registeredAt: mockRegisteredDate,
-                checkedAt: mockDate,
-                source: DomainSource.RDAP,
-                status: DomainStatus.OK,
-            });
-            expect(mapStatusToDomainStatus).toHaveBeenCalledWith(RdapStatus.OK);
+        beforeEach(() => {
+            vi.clearAllMocks();
+            vi.useFakeTimers();
+            vi.setSystemTime(mockDate);
         });
 
-        it('should use RDAP even if WHOIS has later checkedAt', () => {
-            // Arrange
-            const laterDate = new Date('2024-01-15T11:30:00Z');
-            const rdap = {
-                registeredAt: mockRegisteredDate,
-                status: RdapStatus.OK,
-                checkedAt: mockDate,
-            };
-
-            const whois = {
-                registeredAt: mockRegisteredDate,
-                status: WhoisStatus.OK,
-                checkedAt: laterDate, // Later check
-            };
-
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
-
-            // Act
-            const result = pickBestKnown(rdap, whois);
-
-            // Assert
-            expect(result.source).toBe(DomainSource.RDAP);
-            expect(result.checkedAt).toBe(mockDate); // Still uses RDAP's checkedAt
-        });
-    });
-
-    describe('RDAP has no registration date, WHOIS has', () => {
-        it('should prefer WHOIS when WHOIS has registeredAt and RDAP does not', () => {
-            // Arrange
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.MISSING,
-                checkedAt: mockDate,
-            };
-
-            const whois = {
-                registeredAt: mockRegisteredDate,
-                status: WhoisStatus.OK,
-                checkedAt: mockDate,
-            };
-
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
-
-            // Act
-            const result = pickBestKnown(rdap, whois);
-
-            // Assert
-            expect(result).toEqual({
-                registeredAt: mockRegisteredDate,
-                checkedAt: mockDate,
-                source: DomainSource.WHOIS,
-                status: DomainStatus.OK,
-            });
-            expect(mapStatusToDomainStatus).toHaveBeenCalledWith(WhoisStatus.OK);
+        afterEach(() => {
+            vi.useRealTimers();
         });
 
-        it('should use WHOIS checkedAt when selecting WHOIS', () => {
-            // Arrange
-            const whoisCheckedAt = new Date('2024-01-15T09:30:00Z');
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.MISSING,
-                checkedAt: mockDate,
-            };
+        describe('RDAP has registration date', () => {
+            it('Should prefer RDAP when RDAP has registeredAt date', () => {
+                // Arrange
+                const rdap = {
+                    registeredAt: mockRegisteredDate,
+                    status: RdapStatus.OK,
+                    checkedAt: mockDate,
+                    source: 'RDAP' as const,
+                };
 
-            const whois = {
-                registeredAt: mockRegisteredDate,
-                status: WhoisStatus.OK,
-                checkedAt: whoisCheckedAt,
-            };
+                const whois = {
+                    registeredAt: mockRegisteredDate,
+                    status: WhoisStatus.OK,
+                    checkedAt: new Date('2024-01-15T09:30:00Z'), // Earlier check
+                };
 
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
 
-            // Act
-            const result = pickBestKnown(rdap, whois);
-
-            // Assert
-            expect(result.checkedAt).toBe(whoisCheckedAt);
-            expect(result.source).toBe(DomainSource.WHOIS);
-        });
-    });
-
-    describe('Neither has registration date', () => {
-        it('should prefer WHOIS when WHOIS has higher priority status', () => {
-            // Arrange
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.ERROR,
-                checkedAt: mockDate,
-            };
-
-            const whois = {
-                registeredAt: null,
-                status: WhoisStatus.REDACTED,
-                checkedAt: mockDate,
-            };
-
-            (mapStatusToDomainStatus as Mock)
-                .mockReturnValueOnce(DomainStatus.ERROR) // First call for rdap
-                .mockReturnValueOnce(DomainStatus.REDACTED); // Second call for whois
-
-            (getStatusPriority as Mock)
-                .mockReturnValueOnce(1) // ERROR priority
-                .mockReturnValueOnce(4); // REDACTED priority
-
-            // Act
-            const result = pickBestKnown(rdap, whois);
-
-            // Assert
-            expect(result).toEqual({
-                registeredAt: null,
-                checkedAt: mockDate,
-                source: DomainSource.RDAP,
-                status: DomainStatus.ERROR,
-            });
-            expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.ERROR);
-            expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.REDACTED);
-        });
-
-        it('should prefer RDAP when RDAP has higher priority status', () => {
-            // Arrange
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.MISSING,
-                checkedAt: mockDate,
-            };
-
-            const whois = {
-                registeredAt: null,
-                status: WhoisStatus.ERROR,
-                checkedAt: mockDate,
-            };
-
-            console.log('Setting up mocks...');
-
-            (mapStatusToDomainStatus as Mock).mockImplementation((status: RdapStatus | WhoisStatus) => {
-                if (status === RdapStatus.MISSING) {
-                    return DomainStatus.MISSING;
-                }
-                if (status === WhoisStatus.ERROR) {
-                    return DomainStatus.ERROR;
-                }
-                return DomainStatus.UNKNOWN;
-            });
-
-            (getStatusPriority as Mock).mockImplementation((status: DomainStatus) => {
-                if (status === DomainStatus.MISSING) return 3;
-                if (status === DomainStatus.ERROR) return 1;
-                return 0;
-            });
-
-            // Act
-            const result = pickBestKnown(rdap, whois);
-
-            console.log('Result:', result);
-            console.log('Mock calls:', {
-                mapStatusCalls: (mapStatusToDomainStatus as Mock).mock.calls,
-                priorityCalls: (getStatusPriority as Mock).mock.calls,
-            });
-
-            // Assert
-            expect(result.source).toBe(DomainSource.RDAP);
-            expect(result.status).toBe(DomainStatus.MISSING);
-
-            expect(mapStatusToDomainStatus).toHaveBeenCalledTimes(2);
-            expect(mapStatusToDomainStatus).toHaveBeenCalledWith(RdapStatus.MISSING);
-            expect(mapStatusToDomainStatus).toHaveBeenCalledWith(WhoisStatus.ERROR);
-
-            expect(getStatusPriority).toHaveBeenCalledTimes(2);
-            expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.MISSING);
-            expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.ERROR);
-        });
-
-        it('should prefer RDAP when status priorities are equal', () => {
-            // Arrange - Both have same status priority
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.MISSING,
-                checkedAt: mockDate,
-            };
-
-            const whois = {
-                registeredAt: null,
-                status: WhoisStatus.MISSING,
-                checkedAt: new Date('2024-01-15T09:30:00Z'), // Earlier check
-            };
-
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.MISSING);
-
-            (getStatusPriority as Mock).mockReturnValue(3); // Same priority for both
-
-            // Act
-            const result = pickBestKnown(rdap, whois);
-
-            // Assert - Should default to RDAP when priorities are equal
-            expect(result.source).toBe(DomainSource.RDAP);
-        });
-    });
-
-    describe('WHOIS is null', () => {
-        it('should use RDAP when WHOIS is null', () => {
-            // Arrange
-            const rdap = {
-                registeredAt: mockRegisteredDate,
-                status: RdapStatus.OK,
-                checkedAt: mockDate,
-            };
-
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
-
-            // Act
-            const result = pickBestKnown(rdap, null);
-
-            // Assert
-            expect(result.source).toBe(DomainSource.RDAP);
-            expect(result.registeredAt).toBe(mockRegisteredDate);
-        });
-
-        it('should use RDAP when WHOIS is null and RDAP has no registration', () => {
-            // Arrange
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.MISSING,
-                checkedAt: mockDate,
-            };
-
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.MISSING);
-
-            // Act
-            const result = pickBestKnown(rdap, null);
-
-            // Assert
-            expect(result).toEqual({
-                registeredAt: null,
-                checkedAt: mockDate,
-                source: DomainSource.RDAP,
-                status: DomainStatus.MISSING,
-            });
-        });
-
-        it('should handle WHOIS as UNKNOWN when null', () => {
-            // Arrange
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.ERROR,
-                checkedAt: mockDate,
-            };
-
-            (mapStatusToDomainStatus as Mock)
-                .mockReturnValueOnce(DomainStatus.ERROR)
-                .mockReturnValueOnce(DomainStatus.UNKNOWN); // For null whois
-
-            (getStatusPriority as Mock)
-                .mockReturnValueOnce(1) // ERROR priority
-                .mockReturnValueOnce(0); // UNKNOWN priority
-
-            // Act
-            const result = pickBestKnown(rdap, null);
-
-            // Assert - Should use RDAP since ERROR > UNKNOWN
-            expect(result.source).toBe(DomainSource.RDAP);
-            expect(result.status).toBe(DomainStatus.ERROR);
-        });
-    });
-
-    describe('Edge cases', () => {
-        it('throws if RDAP.checkedAt is missing (invariant violation)', () => {
-            const rdap = {
-                registeredAt: mockRegisteredDate,
-                status: RdapStatus.OK,
-                checkedAt: undefined,
-            } as RdapDomainParams;
-
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
-
-            expect(() => pickBestKnown(rdap, null)).toThrow('Invariant violated: rdap.checkedAt is missing');
-        });
-
-        it('throws when WHOIS is selected but whois.checkedAt is missing (invariant)', () => {
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.ERROR,
-                checkedAt: mockDate,
-            } as RdapDomainParams;
-
-            const whois = {
-                registeredAt: null,
-                status: WhoisStatus.REDACTED,
-                checkedAt: undefined,
-            } as WhoisDomainParams;
-
-            (mapStatusToDomainStatus as Mock)
-                .mockReturnValueOnce(DomainStatus.ERROR) // rdapStatus
-                .mockReturnValueOnce(DomainStatus.REDACTED); // whoisStatus
-
-            (getStatusPriority as Mock).mockReturnValueOnce(1).mockReturnValueOnce(4);
-
-            expect(() => pickBestKnown(rdap, whois)).toThrow('Invariant violated: whois.checkedAt is missing');
-        });
-
-        it('should use non-null assertion for checkedAt in final return', () => {
-            // This tests that the function handles the non-null assertion correctly
-            const rdap = {
-                registeredAt: null,
-                status: RdapStatus.OK,
-                checkedAt: mockDate,
-            };
-
-            (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
-
-            const result = pickBestKnown(rdap, null);
-
-            expect(result.checkedAt).toBe(mockDate);
-        });
-    });
-
-    describe('Status priority comparisons', () => {
-        const mockDate = new Date('2025-01-01T00:00:00Z');
-
-        const statusCombinations = [
-            { rdapStatus: RdapStatus.OK, whoisStatus: WhoisStatus.REDACTED, expectedSource: DomainSource.RDAP },
-            { rdapStatus: RdapStatus.REDACTED, whoisStatus: WhoisStatus.MISSING, expectedSource: DomainSource.RDAP },
-            // ...
-        ];
-
-        statusCombinations.forEach(({ rdapStatus, whoisStatus, expectedSource }) => {
-            it(`selects ${expectedSource} when RDAP=${rdapStatus} WHOIS=${whoisStatus}`, () => {
-                const rdap = { registeredAt: null, status: rdapStatus, checkedAt: mockDate } as RdapDomainParams;
-                const whois = { registeredAt: null, status: whoisStatus, checkedAt: mockDate } as WhoisDomainParams;
-
+                // Act
                 const result = pickBestKnown(rdap, whois);
-                expect(result.source).toBe(expectedSource);
+
+                // Assert
+                expect(result).toEqual({
+                    registeredAt: mockRegisteredDate,
+                    checkedAt: mockDate,
+                    source: DomainSource.RDAP,
+                    status: DomainStatus.OK,
+                });
+                expect(mapStatusToDomainStatus).toHaveBeenCalledWith(RdapStatus.OK);
             });
+
+            it('Should use RDAP even if WHOIS has later checkedAt', () => {
+                // Arrange
+                const laterDate = new Date('2024-01-15T11:30:00Z');
+                const rdap = {
+                    registeredAt: mockRegisteredDate,
+                    status: RdapStatus.OK,
+                    checkedAt: mockDate,
+                };
+
+                const whois = {
+                    registeredAt: mockRegisteredDate,
+                    status: WhoisStatus.OK,
+                    checkedAt: laterDate, // Later check
+                };
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+
+                // Act
+                const result = pickBestKnown(rdap, whois);
+
+                // Assert
+                expect(result.source).toBe(DomainSource.RDAP);
+                expect(result.checkedAt).toBe(mockDate); // Still uses RDAP's checkedAt
+            });
+        });
+
+        describe('RDAP has no registration date, WHOIS has', () => {
+            it('Should prefer WHOIS when WHOIS has registeredAt and RDAP does not', () => {
+                // Arrange
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.MISSING,
+                    checkedAt: mockDate,
+                };
+
+                const whois = {
+                    registeredAt: mockRegisteredDate,
+                    status: WhoisStatus.OK,
+                    checkedAt: mockDate,
+                };
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+
+                // Act
+                const result = pickBestKnown(rdap, whois);
+
+                // Assert
+                expect(result).toEqual({
+                    registeredAt: mockRegisteredDate,
+                    checkedAt: mockDate,
+                    source: DomainSource.WHOIS,
+                    status: DomainStatus.OK,
+                });
+                expect(mapStatusToDomainStatus).toHaveBeenCalledWith(WhoisStatus.OK);
+            });
+
+            it('Should use WHOIS checkedAt when selecting WHOIS', () => {
+                // Arrange
+                const whoisCheckedAt = new Date('2024-01-15T09:30:00Z');
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.MISSING,
+                    checkedAt: mockDate,
+                };
+
+                const whois = {
+                    registeredAt: mockRegisteredDate,
+                    status: WhoisStatus.OK,
+                    checkedAt: whoisCheckedAt,
+                };
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+
+                // Act
+                const result = pickBestKnown(rdap, whois);
+
+                // Assert
+                expect(result.checkedAt).toBe(whoisCheckedAt);
+                expect(result.source).toBe(DomainSource.WHOIS);
+            });
+        });
+
+        describe('Neither has registration date', () => {
+            it('Should prefer WHOIS when WHOIS has higher priority status', () => {
+                // Arrange
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.ERROR,
+                    checkedAt: mockDate,
+                };
+
+                const whois = {
+                    registeredAt: null,
+                    status: WhoisStatus.REDACTED,
+                    checkedAt: mockDate,
+                };
+
+                (mapStatusToDomainStatus as Mock)
+                    .mockReturnValueOnce(DomainStatus.ERROR) // First call for rdap
+                    .mockReturnValueOnce(DomainStatus.REDACTED); // Second call for whois
+
+                (getStatusPriority as Mock)
+                    .mockReturnValueOnce(1) // ERROR priority
+                    .mockReturnValueOnce(4); // REDACTED priority
+
+                // Act
+                const result = pickBestKnown(rdap, whois);
+
+                // Assert
+                expect(result).toEqual({
+                    registeredAt: null,
+                    checkedAt: mockDate,
+                    source: DomainSource.RDAP,
+                    status: DomainStatus.ERROR,
+                });
+                expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.ERROR);
+                expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.REDACTED);
+            });
+
+            it('Should prefer RDAP when RDAP has higher priority status', () => {
+                // Arrange
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.MISSING,
+                    checkedAt: mockDate,
+                };
+
+                const whois = {
+                    registeredAt: null,
+                    status: WhoisStatus.ERROR,
+                    checkedAt: mockDate,
+                };
+
+                console.log('Setting up mocks...');
+
+                (mapStatusToDomainStatus as Mock).mockImplementation((status: RdapStatus | WhoisStatus) => {
+                    if (status === RdapStatus.MISSING) {
+                        return DomainStatus.MISSING;
+                    }
+                    if (status === WhoisStatus.ERROR) {
+                        return DomainStatus.ERROR;
+                    }
+                    return DomainStatus.UNKNOWN;
+                });
+
+                (getStatusPriority as Mock).mockImplementation((status: DomainStatus) => {
+                    if (status === DomainStatus.MISSING) return 3;
+                    if (status === DomainStatus.ERROR) return 1;
+                    return 0;
+                });
+
+                // Act
+                const result = pickBestKnown(rdap, whois);
+
+                console.log('Result:', result);
+                console.log('Mock calls:', {
+                    mapStatusCalls: (mapStatusToDomainStatus as Mock).mock.calls,
+                    priorityCalls: (getStatusPriority as Mock).mock.calls,
+                });
+
+                // Assert
+                expect(result.source).toBe(DomainSource.RDAP);
+                expect(result.status).toBe(DomainStatus.MISSING);
+
+                expect(mapStatusToDomainStatus).toHaveBeenCalledTimes(2);
+                expect(mapStatusToDomainStatus).toHaveBeenCalledWith(RdapStatus.MISSING);
+                expect(mapStatusToDomainStatus).toHaveBeenCalledWith(WhoisStatus.ERROR);
+
+                expect(getStatusPriority).toHaveBeenCalledTimes(2);
+                expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.MISSING);
+                expect(getStatusPriority).toHaveBeenCalledWith(DomainStatus.ERROR);
+            });
+
+            it('Should prefer RDAP when status priorities are equal', () => {
+                // Arrange - Both have same status priority
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.MISSING,
+                    checkedAt: mockDate,
+                };
+
+                const whois = {
+                    registeredAt: null,
+                    status: WhoisStatus.MISSING,
+                    checkedAt: new Date('2024-01-15T09:30:00Z'), // Earlier check
+                };
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.MISSING);
+
+                (getStatusPriority as Mock).mockReturnValue(3); // Same priority for both
+
+                // Act
+                const result = pickBestKnown(rdap, whois);
+
+                // Assert - Should default to RDAP when priorities are equal
+                expect(result.source).toBe(DomainSource.RDAP);
+            });
+        });
+
+        describe('WHOIS is null', () => {
+            it('Should use RDAP when WHOIS is null', () => {
+                // Arrange
+                const rdap = {
+                    registeredAt: mockRegisteredDate,
+                    status: RdapStatus.OK,
+                    checkedAt: mockDate,
+                };
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+
+                // Act
+                const result = pickBestKnown(rdap, null);
+
+                // Assert
+                expect(result.source).toBe(DomainSource.RDAP);
+                expect(result.registeredAt).toBe(mockRegisteredDate);
+            });
+
+            it('Should use RDAP when WHOIS is null and RDAP has no registration', () => {
+                // Arrange
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.MISSING,
+                    checkedAt: mockDate,
+                };
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.MISSING);
+
+                // Act
+                const result = pickBestKnown(rdap, null);
+
+                // Assert
+                expect(result).toEqual({
+                    registeredAt: null,
+                    checkedAt: mockDate,
+                    source: DomainSource.RDAP,
+                    status: DomainStatus.MISSING,
+                });
+            });
+
+            it('Should handle WHOIS as UNKNOWN when null', () => {
+                // Arrange
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.ERROR,
+                    checkedAt: mockDate,
+                };
+
+                (mapStatusToDomainStatus as Mock)
+                    .mockReturnValueOnce(DomainStatus.ERROR)
+                    .mockReturnValueOnce(DomainStatus.UNKNOWN); // For null whois
+
+                (getStatusPriority as Mock)
+                    .mockReturnValueOnce(1) // ERROR priority
+                    .mockReturnValueOnce(0); // UNKNOWN priority
+
+                // Act
+                const result = pickBestKnown(rdap, null);
+
+                // Assert - Should use RDAP since ERROR > UNKNOWN
+                expect(result.source).toBe(DomainSource.RDAP);
+                expect(result.status).toBe(DomainStatus.ERROR);
+            });
+        });
+
+        describe('Edge cases', () => {
+            it('throws if RDAP.checkedAt is missing (invariant violation)', () => {
+                const rdap = {
+                    registeredAt: mockRegisteredDate,
+                    status: RdapStatus.OK,
+                    checkedAt: undefined,
+                } as RdapDomainParams;
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+
+                expect(() => pickBestKnown(rdap, null)).toThrow('Invariant violated: rdap.checkedAt is missing');
+            });
+
+            it('throws when WHOIS is selected but whois.checkedAt is missing (invariant)', () => {
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.ERROR,
+                    checkedAt: mockDate,
+                } as RdapDomainParams;
+
+                const whois = {
+                    registeredAt: null,
+                    status: WhoisStatus.REDACTED,
+                    checkedAt: undefined,
+                } as WhoisDomainParams;
+
+                (mapStatusToDomainStatus as Mock)
+                    .mockReturnValueOnce(DomainStatus.ERROR) // rdapStatus
+                    .mockReturnValueOnce(DomainStatus.REDACTED); // whoisStatus
+
+                (getStatusPriority as Mock).mockReturnValueOnce(1).mockReturnValueOnce(4);
+
+                expect(() => pickBestKnown(rdap, whois)).toThrow('Invariant violated: whois.checkedAt is missing');
+            });
+
+            it('Should use non-null assertion for checkedAt in final return', () => {
+                // This tests that the function handles the non-null assertion correctly
+                const rdap = {
+                    registeredAt: null,
+                    status: RdapStatus.OK,
+                    checkedAt: mockDate,
+                };
+
+                (mapStatusToDomainStatus as Mock).mockReturnValue(DomainStatus.OK);
+
+                const result = pickBestKnown(rdap, null);
+
+                expect(result.checkedAt).toBe(mockDate);
+            });
+        });
+
+        describe('Status priority comparisons', () => {
+            const mockDate = new Date('2025-01-01T00:00:00Z');
+
+            const statusCombinations = [
+                { rdapStatus: RdapStatus.OK, whoisStatus: WhoisStatus.REDACTED, expectedSource: DomainSource.RDAP },
+                {
+                    rdapStatus: RdapStatus.REDACTED,
+                    whoisStatus: WhoisStatus.MISSING,
+                    expectedSource: DomainSource.RDAP,
+                },
+                // ...
+            ];
+
+            statusCombinations.forEach(({ rdapStatus, whoisStatus, expectedSource }) => {
+                it(`selects ${expectedSource} when RDAP=${rdapStatus} WHOIS=${whoisStatus}`, () => {
+                    const rdap = { registeredAt: null, status: rdapStatus, checkedAt: mockDate } as RdapDomainParams;
+                    const whois = { registeredAt: null, status: whoisStatus, checkedAt: mockDate } as WhoisDomainParams;
+
+                    const result = pickBestKnown(rdap, whois);
+                    expect(result.source).toBe(expectedSource);
+                });
+            });
+        });
+    });
+
+    describe('Generate domain enrichment job summary tests', () => {
+        const mockJobId = 'job-123';
+        const mockDomainId = 'domain-456';
+
+        const baseJob = {
+            id: mockJobId,
+            domainId: mockDomainId,
+            status: DomainEnrichmentJobStatus.PENDING,
+            runAfter: new Date(),
+            attempts: 0,
+            lastError: null,
+            lockedUntil: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        } as DomainEnrichmentJob;
+
+        const baseDomain = {
+            id: mockDomainId,
+            hostname: 'example.com',
+            firstSeenAt: new Date(),
+            source: DomainSource.UNKNOWN,
+            status: DomainStatus.UNKNOWN,
+            registeredAt: null,
+            checkedAt: null,
+            rdapRaw: null,
+            rdapFetchedAt: null,
+            whoisRaw: null,
+            whoisFetchedAt: null,
+            rdapFetchLockedUntil: null,
+            whoisFetchLockedUntil: null,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+        } as Domain;
+
+        beforeEach(() => {
+            vi.clearAllMocks();
+        });
+
+        afterEach(() => {
+            vi.resetAllMocks();
+        });
+
+        it('Should return null and log warning when job is not found', async () => {
+            // Arrange
+            mockGetDomainEnrichmentJobById.mockResolvedValue(null);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(mockGetDomainEnrichmentJobById).toHaveBeenCalledTimes(1);
+            expect(mockGetDomainEnrichmentJobById).toHaveBeenCalledWith(mockJobId);
+            expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+            expect(mockLoggerWarn).toHaveBeenCalledWith(`Could not find domain enrichment job with ID=${mockJobId}`);
+            expect(result).toBeNull();
+            expect(mockGetDomainById).not.toHaveBeenCalled();
+        });
+
+        it('Should return null and log warning when domain is not found', async () => {
+            // Arrange
+            const job = { ...baseJob };
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(null);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(mockGetDomainEnrichmentJobById).toHaveBeenCalledTimes(1);
+            expect(mockGetDomainEnrichmentJobById).toHaveBeenCalledWith(mockJobId);
+            expect(mockGetDomainById).toHaveBeenCalledTimes(1);
+            expect(mockGetDomainById).toHaveBeenCalledWith(mockDomainId);
+            expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+            expect(mockLoggerWarn).toHaveBeenCalledWith(`Could not find domain with ID=${mockDomainId}`);
+            expect(result).toBeNull();
+        });
+
+        it('Should generate summary for domain with registeredAt date', async () => {
+            // Arrange
+            const job = {
+                ...baseJob,
+                status: DomainEnrichmentJobStatus.DONE,
+            };
+            const domain = {
+                ...baseDomain,
+                registeredAt: new Date('2020-01-01T00:00:00.000Z'),
+                source: DomainSource.RDAP,
+                status: DomainStatus.OK,
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(mockGetDomainEnrichmentJobById).toHaveBeenCalledWith(mockJobId);
+            expect(mockGetDomainById).toHaveBeenCalledWith(mockDomainId);
+            expect(mockLoggerWarn).not.toHaveBeenCalled();
+
+            expect(result).toEqual({
+                registeredAtFound: true,
+                provider: DomainSource.RDAP,
+                domainStatus: DomainStatus.OK,
+                jobStatus: DomainEnrichmentJobStatus.DONE,
+            });
+        });
+
+        it('Should generate summary for domain without registeredAt date', async () => {
+            // Arrange
+            const job = {
+                ...baseJob,
+                status: DomainEnrichmentJobStatus.PENDING,
+            };
+            const domain = {
+                ...baseDomain,
+                registeredAt: null, // No registration date
+                source: DomainSource.WHOIS,
+                status: DomainStatus.MISSING,
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(result).toEqual({
+                registeredAtFound: false,
+                provider: DomainSource.WHOIS,
+                domainStatus: DomainStatus.MISSING,
+                jobStatus: DomainEnrichmentJobStatus.PENDING,
+            });
+        });
+
+        it('Should handle all DomainSource enum values', async () => {
+            // Test for RDAP
+            const job1 = { ...baseJob };
+            const domain1 = {
+                ...baseDomain,
+                source: DomainSource.RDAP,
+                registeredAt: new Date(),
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job1);
+            mockGetDomainById.mockResolvedValue(domain1);
+
+            const result1 = await generateDomainEnrichmentJobSummary(mockJobId);
+            expect(result1?.provider).toBe(DomainSource.RDAP);
+
+            // Test for WHOIS
+            const job2 = { ...baseJob };
+            const domain2 = {
+                ...baseDomain,
+                source: DomainSource.WHOIS,
+                registeredAt: new Date(),
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job2);
+            mockGetDomainById.mockResolvedValue(domain2);
+
+            const result2 = await generateDomainEnrichmentJobSummary('job-2');
+            expect(result2?.provider).toBe(DomainSource.WHOIS);
+
+            // Test for UNKNOWN
+            const job3 = { ...baseJob };
+            const domain3 = {
+                ...baseDomain,
+                source: DomainSource.UNKNOWN,
+                registeredAt: null,
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job3);
+            mockGetDomainById.mockResolvedValue(domain3);
+
+            const result3 = await generateDomainEnrichmentJobSummary('job-3');
+            expect(result3?.provider).toBe(DomainSource.UNKNOWN);
+        });
+
+        it('Should handle all DomainStatus enum values', async () => {
+            const statuses = [
+                DomainStatus.OK,
+                DomainStatus.MISSING,
+                DomainStatus.REDACTED,
+                DomainStatus.ERROR,
+                DomainStatus.UNSUPPORTED,
+                DomainStatus.UNKNOWN,
+            ];
+
+            for (const domainStatus of statuses) {
+                const job = { ...baseJob };
+                const domain = {
+                    ...baseDomain,
+                    status: domainStatus,
+                    registeredAt: new Date(),
+                };
+
+                mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+                mockGetDomainById.mockResolvedValue(domain);
+
+                const result = await generateDomainEnrichmentJobSummary(`job-${domainStatus}`);
+                expect(result?.domainStatus).toBe(domainStatus);
+            }
+        });
+
+        it('Should handle all DomainEnrichmentJobStatus enum values', async () => {
+            const statuses = [
+                DomainEnrichmentJobStatus.PENDING,
+                DomainEnrichmentJobStatus.RUNNING,
+                DomainEnrichmentJobStatus.DONE,
+                DomainEnrichmentJobStatus.ERROR,
+            ];
+
+            for (const jobStatus of statuses) {
+                const job = { ...baseJob, status: jobStatus };
+                const domain = {
+                    ...baseDomain,
+                    registeredAt: new Date(),
+                };
+
+                mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+                mockGetDomainById.mockResolvedValue(domain);
+
+                const result = await generateDomainEnrichmentJobSummary(`job-${jobStatus}`);
+                expect(result?.jobStatus).toBe(jobStatus);
+            }
+        });
+
+        it('Should handle job with ERROR status and domain with ERROR status', async () => {
+            // Arrange
+            const job = {
+                ...baseJob,
+                status: DomainEnrichmentJobStatus.ERROR,
+                lastError: 'Failed to fetch RDAP data',
+            };
+            const domain = {
+                ...baseDomain,
+                source: DomainSource.UNKNOWN,
+                status: DomainStatus.ERROR,
+                registeredAt: null,
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(result).toEqual({
+                registeredAtFound: false,
+                provider: DomainSource.UNKNOWN,
+                domainStatus: DomainStatus.ERROR,
+                jobStatus: DomainEnrichmentJobStatus.ERROR,
+            });
+        });
+
+        it('Should handle job RUNNING with domain REDACTED status', async () => {
+            // Arrange
+            const job = {
+                ...baseJob,
+                status: DomainEnrichmentJobStatus.RUNNING,
+            };
+            const domain = {
+                ...baseDomain,
+                source: DomainSource.RDAP,
+                status: DomainStatus.REDACTED,
+                registeredAt: new Date('2021-06-15T00:00:00.000Z'),
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(result).toEqual({
+                registeredAtFound: true,
+                provider: DomainSource.RDAP,
+                domainStatus: DomainStatus.REDACTED,
+                jobStatus: DomainEnrichmentJobStatus.RUNNING,
+            });
+        });
+
+        it('Should handle job DONE with domain UNSUPPORTED status', async () => {
+            // Arrange
+            const job = {
+                ...baseJob,
+                status: DomainEnrichmentJobStatus.DONE,
+            };
+            const domain = {
+                ...baseDomain,
+                source: DomainSource.WHOIS,
+                status: DomainStatus.UNSUPPORTED,
+                registeredAt: null,
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(result).toEqual({
+                registeredAtFound: false,
+                provider: DomainSource.WHOIS,
+                domainStatus: DomainStatus.UNSUPPORTED,
+                jobStatus: DomainEnrichmentJobStatus.DONE,
+            });
+        });
+
+        it('Should handle job with future registeredAt date', async () => {
+            // Arrange
+            const job = { ...baseJob };
+            const futureDate = new Date(Date.now() + 86400000); // +1 day
+            const domain = {
+                ...baseDomain,
+                registeredAt: futureDate,
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(result?.registeredAtFound).toBe(true);
+        });
+
+        it('Should handle job with past registeredAt date', async () => {
+            // Arrange
+            const job = { ...baseJob };
+            const pastDate = new Date('2010-05-20T00:00:00.000Z');
+            const domain = {
+                ...baseDomain,
+                registeredAt: pastDate,
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(result?.registeredAtFound).toBe(true);
+        });
+
+        it('Should not include other domain fields in summary', async () => {
+            // Arrange
+            const job = { ...baseJob };
+            const domain = {
+                ...baseDomain,
+                registeredAt: new Date(),
+                hostname: 'test.example.com',
+                firstSeenAt: new Date(),
+                // ... other fields that Should NOT be in summary
+            };
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockResolvedValue(domain);
+
+            // Act
+            const result = await generateDomainEnrichmentJobSummary(mockJobId);
+
+            // Assert
+            expect(result).toMatchObject({
+                registeredAtFound: expect.any(Boolean),
+                provider: expect.any(String),
+                domainStatus: expect.any(String),
+                jobStatus: expect.any(String),
+            });
+
+            // Ensure only expected fields are present
+            const resultKeys = Object.keys(result || {});
+            expect(resultKeys).toEqual(['registeredAtFound', 'provider', 'domainStatus', 'jobStatus']);
+        });
+
+        it('Should handle concurrent calls with different job IDs', async () => {
+            // Arrange
+            const jobs = [
+                { id: 'job-1', domainId: 'domain-1', status: DomainEnrichmentJobStatus.PENDING },
+                { id: 'job-2', domainId: 'domain-2', status: DomainEnrichmentJobStatus.RUNNING },
+                { id: 'job-3', domainId: 'domain-3', status: DomainEnrichmentJobStatus.DONE },
+            ];
+
+            const domains = [
+                { id: 'domain-1', source: DomainSource.RDAP, status: DomainStatus.OK, registeredAt: new Date() },
+                { id: 'domain-2', source: DomainSource.WHOIS, status: DomainStatus.MISSING, registeredAt: null },
+                { id: 'domain-3', source: DomainSource.UNKNOWN, status: DomainStatus.ERROR, registeredAt: null },
+            ];
+
+            // Setup mocks for each call
+            jobs.forEach((job, index) => {
+                mockGetDomainEnrichmentJobById.mockResolvedValueOnce({ ...baseJob, ...job } as DomainEnrichmentJob);
+                mockGetDomainById.mockResolvedValueOnce({ ...baseDomain, ...domains[index] } as Domain);
+            });
+
+            // Act - make concurrent calls
+            const promises = jobs.map((job) => generateDomainEnrichmentJobSummary(job.id));
+            const results = await Promise.all(promises);
+
+            // Assert
+            expect(results).toHaveLength(3);
+
+            expect(results[0]).toEqual({
+                registeredAtFound: true,
+                provider: DomainSource.RDAP,
+                domainStatus: DomainStatus.OK,
+                jobStatus: DomainEnrichmentJobStatus.PENDING,
+            });
+
+            expect(results[1]).toEqual({
+                registeredAtFound: false,
+                provider: DomainSource.WHOIS,
+                domainStatus: DomainStatus.MISSING,
+                jobStatus: DomainEnrichmentJobStatus.RUNNING,
+            });
+
+            expect(results[2]).toEqual({
+                registeredAtFound: false,
+                provider: DomainSource.UNKNOWN,
+                domainStatus: DomainStatus.ERROR,
+                jobStatus: DomainEnrichmentJobStatus.DONE,
+            });
+        });
+
+        it('Should propagate errors from getDomainEnrichmentJobById', async () => {
+            // Arrange
+            const error = new Error('Database connection failed');
+            mockGetDomainEnrichmentJobById.mockRejectedValue(error);
+
+            // Act & Assert
+            await expect(generateDomainEnrichmentJobSummary(mockJobId)).rejects.toThrow('Database connection failed');
+            expect(mockGetDomainEnrichmentJobById).toHaveBeenCalledTimes(1);
+            expect(mockGetDomainById).not.toHaveBeenCalled();
+        });
+
+        it('Should propagate errors from getDomainById', async () => {
+            // Arrange
+            const job = { ...baseJob };
+            const error = new Error('Domain query failed');
+
+            mockGetDomainEnrichmentJobById.mockResolvedValue(job);
+            mockGetDomainById.mockRejectedValue(error);
+
+            // Act & Assert
+            await expect(generateDomainEnrichmentJobSummary(mockJobId)).rejects.toThrow('Domain query failed');
+            expect(mockGetDomainEnrichmentJobById).toHaveBeenCalledTimes(1);
+            expect(mockGetDomainById).toHaveBeenCalledTimes(1);
         });
     });
 });

--- a/worker/domain_enrichment_worker.ts
+++ b/worker/domain_enrichment_worker.ts
@@ -6,8 +6,13 @@ import {
 } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
 import { processDomainEnrichment } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.service';
 import { prisma } from '@/lib/prisma';
+import { logger } from '@/lib/logging/logger';
+import { ClaimedDomainJob } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.types';
+import { LoggerLike } from '@/lib/logging/logger.types';
+import { DomainEnrichmentJobResult } from '@/worker/domain_enrichment_worker_types';
 
 const IDLE_SLEEP_MS = 1000;
+const workerLog = logger.with({ component: 'worker.domain_enrichment' }, ['worker', 'domain-enrichment']);
 
 function sleep(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
@@ -29,6 +34,21 @@ function normalizeError(error: unknown): Error {
     } catch {
         return new Error('Unknown error');
     }
+}
+
+function getScopedClientJobLog(job: ClaimedDomainJob | null): LoggerLike {
+    if (!job) return logger;
+
+    return logger.with(
+        {
+            component: 'worker.domain_enrichment',
+            jobId: job.id,
+            domainId: job.domainId,
+            hostname: job.hostname,
+            attempt: job.attempts,
+        },
+        ['worker', 'domain-enrichment']
+    );
 }
 
 function getLockOrDefault(lock: Date | null): Date | null {
@@ -58,20 +78,30 @@ async function getNextAllowedRunAfter(domainId: string): Promise<Date | null> {
 
 async function main(): Promise<void> {
     while (true) {
-        console.warn("Attempting to claim next domain enrichment job");
+        workerLog.debug('Attempting to claim the next job');
         const job = await claimNextDomainEnrichmentJob();
 
         if (!job) {
-            //TODO: Add log here
-            console.warn(`No jobs found. Sleeping for ${IDLE_SLEEP_MS}ms...`);
+            workerLog.debug(`No jobs found. Sleeping for ${IDLE_SLEEP_MS}ms...`);
             await sleep(IDLE_SLEEP_MS);
             continue;
         }
+
+        const startedAtMs = Date.now();
+        const scopedJobLog = getScopedClientJobLog(job);
+        scopedJobLog.debug('Job claimed');
 
         try {
             const runAfter = await getNextAllowedRunAfter(job.domainId);
 
             if (runAfter) {
+                scopedJobLog.warn('Provider locked. Attempting to requeue job', {
+                    result: 'FAILED' satisfies DomainEnrichmentJobResult,
+                    durationMs: msSince(startedAtMs),
+                    runAfter: runAfter.toISOString(),
+                    reason: 'Domain provider locked',
+                });
+
                 await requeueDomainEnrichmentJob({
                     jobId: job.id,
                     attempts: job.attempts,
@@ -81,19 +111,34 @@ async function main(): Promise<void> {
                 continue;
             }
 
+            //TODO return statuses from processDomainEnrichment func
+            // Eg: { rdapStatus?: string; whoisStatus?: string }
+
             await processDomainEnrichment(job.hostname, job.domainId);
             await markDomainEnrichmentJobAsDone(job.id);
+
+            scopedJobLog.info('Job finished', {
+                result: 'DONE' satisfies DomainEnrichmentJobResult,
+                durationMs: Date.now() - startedAtMs,
+            });
         } catch (error) {
             const normalizedError = normalizeError(error);
-            // TODO: Add logging and remove the console.error(...)
-            console.error('Domain enrichment worker job failed:', { ...job, error });
+
+            scopedJobLog.error('Job failed', {
+                result: 'FAILED' satisfies DomainEnrichmentJobResult,
+                durationMs: Date.now() - startedAtMs,
+                error: error,
+            });
             await requeueDomainEnrichmentJob({ jobId: job.id, attempts: job.attempts, error: normalizedError });
         }
     }
 }
 
-main().catch( async (error) => {
-    console.error(`FATAL DOMAIN ENRICHMENT WORKER ERROR: ${error}`);
+main().catch(async (error) => {
+    logger.error('FATAL DOMAIN ENRICHMENT WORKER ERROR', {
+        component: 'worker.domain_enrichment',
+        error,
+    });
     await prisma.$disconnect();
     process.exit(1);
-})
+});

--- a/worker/domain_enrichment_worker.ts
+++ b/worker/domain_enrichment_worker.ts
@@ -17,6 +17,20 @@ function minDate(a: Date, b: Date): Date {
     return a.getTime() <= b.getTime() ? a : b;
 }
 
+function msSince(startMs: number): number {
+    return Date.now() - startMs;
+}
+
+function normalizeError(error: unknown): Error {
+    if (error instanceof Error) return error;
+    if (typeof error === 'string') return new Error(error);
+    try {
+        return new Error(JSON.stringify(error));
+    } catch {
+        return new Error('Unknown error');
+    }
+}
+
 function getLockOrDefault(lock: Date | null): Date | null {
     const now = new Date();
 
@@ -70,8 +84,7 @@ async function main(): Promise<void> {
             await processDomainEnrichment(job.hostname, job.domainId);
             await markDomainEnrichmentJobAsDone(job.id);
         } catch (error) {
-            const normalizedError =
-                error instanceof Error ? error : new Error(typeof error === 'string' ? error : JSON.stringify(error));
+            const normalizedError = normalizeError(error);
             // TODO: Add logging and remove the console.error(...)
             console.error('Domain enrichment worker job failed:', { ...job, error });
             await requeueDomainEnrichmentJob({ jobId: job.id, attempts: job.attempts, error: normalizedError });

--- a/worker/domain_enrichment_worker.ts
+++ b/worker/domain_enrichment_worker.ts
@@ -4,7 +4,10 @@ import {
     markDomainEnrichmentJobAsDone,
     requeueDomainEnrichmentJob,
 } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
-import { processDomainEnrichment } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.service';
+import {
+    generateDomainEnrichmentJobSummary,
+    processDomainEnrichment,
+} from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.service';
 import { prisma } from '@/lib/prisma';
 import { logger } from '@/lib/logging/logger';
 import { ClaimedDomainJob } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.types';
@@ -111,15 +114,17 @@ async function main(): Promise<void> {
                 continue;
             }
 
-            //TODO return statuses from processDomainEnrichment func
-            // Eg: { rdapStatus?: string; whoisStatus?: string }
-
             await processDomainEnrichment(job.hostname, job.domainId);
             await markDomainEnrichmentJobAsDone(job.id);
+            const summary = await generateDomainEnrichmentJobSummary(job.id);
 
             scopedJobLog.info('Job finished', {
                 result: 'DONE' satisfies DomainEnrichmentJobResult,
-                durationMs: Date.now() - startedAtMs,
+                durationMs: msSince(startedAtMs),
+                registeredAtFound: summary?.registeredAtFound ?? 'Unknown',
+                provider: summary?.provider ?? 'UNKNOWN',
+                domainStatus: summary?.domainStatus ?? 'UNKNOWN',
+                jobStatus: summary?.jobStatus ?? 'UNKNOWN',
             });
         } catch (error) {
             const normalizedError = normalizeError(error);

--- a/worker/domain_enrichment_worker_types.ts
+++ b/worker/domain_enrichment_worker_types.ts
@@ -1,0 +1,1 @@
+export type DomainEnrichmentJobResult = 'DONE' | 'FAILED';


### PR DESCRIPTION
## Closes #73  
- Add specific status types for the worker
- Provide an util for normalizing errors encountered here
- Add function to retrieve domain by its ID. Provide tests
- Add function to retrieve domain enrichment job by its ID. Provide tests
- Provide method for generating out the domain enrichment job summary. Add tests for it