### PR TITLE
Provide app readiness endpoint check

### DIFF
--- a/app/api/app/readyz/route.ts
+++ b/app/api/app/readyz/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { checkReady } from '@/dal/migrations/migrations.service';
+import { ReadinessError } from '@/lib/errors/ReadinessError';
+import { MigrationDetails } from '@/dal/migrations/migrations.types';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export type AppReadinessResponse =
+    | {
+          ok: true;
+          migrationDetails: MigrationDetails | null;
+      }
+    | {
+          ok: false;
+          reason: 'db' | 'migrations';
+      };
+
+export async function GET() {
+    try {
+        const result: AppReadinessResponse = await checkReady();
+
+        return NextResponse.json(result, {
+            status: 200,
+            headers: { 'cache-control': 'no-store, max-age=0' },
+        });
+    } catch (err) {
+        if (err instanceof ReadinessError) {
+            return NextResponse.json(
+                { ok: false, reason: err.reason },
+                {
+                    status: err.status,
+                    headers: { 'cache-control': 'no-store, max-age=0' },
+                }
+            );
+        }
+
+        return NextResponse.json(
+            { ok: false, reason: 'db' },
+            {
+                status: 503,
+                headers: { 'cache-control': 'no-store, max-age=0' },
+            }
+        );
+    }
+}

--- a/dal/db/db.repo.ts
+++ b/dal/db/db.repo.ts
@@ -1,0 +1,5 @@
+import { prisma } from '@/lib/prisma';
+
+export async function pingDb(): Promise<void> {
+    await prisma.$queryRaw`SELECT 1`;
+}

--- a/dal/db/db.service.ts
+++ b/dal/db/db.service.ts
@@ -1,0 +1,14 @@
+import { pingDb } from '@/dal/db/db.repo';
+import { ReadinessError } from '@/lib/errors/ReadinessError';
+import { logger } from '@/lib/logging/logger';
+
+const log = logger.with({ component: 'db.service.checkDbReachable' });
+
+export async function checkDbReachable(): Promise<void> {
+    try {
+        await pingDb();
+    } catch {
+        log.error(`Database not reachable!`);
+        throw new ReadinessError('database', 'Database not reachable');
+    }
+}

--- a/dal/db/db.service.ts
+++ b/dal/db/db.service.ts
@@ -1,14 +1,15 @@
 import { pingDb } from '@/dal/db/db.repo';
 import { ReadinessError } from '@/lib/errors/ReadinessError';
 import { logger } from '@/lib/logging/logger';
+import { withTimeout } from '@/lib/timeouts';
 
 const log = logger.with({ component: 'db.service.checkDbReachable' });
 
-export async function checkDbReachable(): Promise<void> {
+export async function checkDbReachable(timeoutMs = 2000): Promise<void> {
     try {
-        await pingDb();
-    } catch {
-        log.error(`Database not reachable!`);
+        await withTimeout(pingDb(), timeoutMs);
+    } catch (err) {
+        log.error('Database not reachable', { err, timeoutMs });
         throw new ReadinessError('database', 'Database not reachable');
     }
 }

--- a/dal/migrations/migrations.repo.ts
+++ b/dal/migrations/migrations.repo.ts
@@ -1,0 +1,12 @@
+import { prisma } from '@/lib/prisma';
+
+export async function migrationsTableExists(): Promise<boolean> {
+    const rows = await prisma.$queryRaw<Array<{ exists: boolean }>>`
+    SELECT EXISTS (
+      SELECT 1
+      FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = '_prisma_migrations'
+    ) AS "exists"
+  `;
+    return rows?.[0]?.exists === true;
+}

--- a/dal/migrations/migrations.repo.ts
+++ b/dal/migrations/migrations.repo.ts
@@ -10,3 +10,34 @@ export async function migrationsTableExists(): Promise<boolean> {
   `;
     return rows?.[0]?.exists === true;
 }
+
+export async function countPendingMigrations(): Promise<number> {
+    const tableExists = await migrationsTableExists();
+
+    if (!tableExists) {
+        return 0;
+    }
+
+    const rows = await prisma.$queryRaw<Array<{ count: bigint }>>`
+        SELECT COUNT(*)::bigint AS count
+        FROM "_prisma_migrations"
+        WHERE "finished_at" IS NULL AND "rolled_back_at" IS NULL
+    `;
+    return Number(rows?.[0]?.count ?? 0);
+}
+
+export async function countAppliedMigrations(): Promise<number> {
+    const tableExists = await migrationsTableExists();
+
+    if (!tableExists) {
+        return 0;
+    }
+
+    const rows = await prisma.$queryRaw<Array<{ count: bigint }>>`
+        SELECT COUNT(*)::bigint AS count
+        FROM "_prisma_migrations"
+        WHERE finished_at IS NOT NULL AND "rolled_back_at" IS NULL
+    `;
+
+    return Number(rows?.[0]?.count ?? 0);
+}

--- a/dal/migrations/migrations.repo.ts
+++ b/dal/migrations/migrations.repo.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { MigrationDetails } from '@/dal/migrations/migrations.types';
 
 export async function migrationsTableExists(): Promise<boolean> {
     const rows = await prisma.$queryRaw<Array<{ exists: boolean }>>`
@@ -40,4 +41,37 @@ export async function countAppliedMigrations(): Promise<number> {
     `;
 
     return Number(rows?.[0]?.count ?? 0);
+}
+
+export async function getLastAppliedMigration(): Promise<MigrationDetails | null> {
+
+    const tableExists = await migrationsTableExists();
+
+    if (!tableExists) {
+        return null;
+    }
+
+    const rows = await prisma.$queryRaw<
+        Array<{
+            migration_name: string | null;
+            started_at: Date | null;
+            finished_at: Date | null;
+            applied_steps_count: number | null;
+        }>
+    >`
+        SELECT "migration_name","started_at","finished_at","applied_steps_count"
+        FROM "_prisma_migrations"
+        WHERE "finished_at" IS NOT NULL AND "rolled_back_at" IS NULL
+        ORDER BY "finished_at" DESC
+        LIMIT 1
+    `;
+
+    if (!rows?.[0]) return null;
+
+    return {
+        migrationName: rows[0].migration_name,
+        startedAt: rows[0].started_at,
+        finishedAt: rows[0].finished_at,
+        appliedStepsCount: rows[0].applied_steps_count,
+    };
 }

--- a/dal/migrations/migrations.service.ts
+++ b/dal/migrations/migrations.service.ts
@@ -1,0 +1,21 @@
+import { MigrationDetails } from '@/dal/migrations/migrations.types';
+import { countPendingMigrations, getLastAppliedMigration } from '@/dal/migrations/migrations.repo';
+import { logger } from '@/lib/logging/logger';
+import { ReadinessError } from '@/lib/errors/ReadinessError';
+
+const log = logger.with({ component: 'migrations.service' });
+
+export async function checkDbMigrations(): Promise<MigrationDetails | null> {
+    log.debug('Checking out for database migrations...');
+
+    const pendingMigrations = await countPendingMigrations();
+
+    if (pendingMigrations > 0) {
+        log.error('Database has pending migrations', { pendingMigrations });
+        throw new ReadinessError('migrations', `Database has ${pendingMigrations} unfinished migrations`);
+    }
+
+    const lastMigration = await getLastAppliedMigration();
+
+    return lastMigration ?? null;
+}

--- a/dal/migrations/migrations.service.ts
+++ b/dal/migrations/migrations.service.ts
@@ -3,6 +3,7 @@ import { countPendingMigrations, getLastAppliedMigration } from '@/dal/migration
 import { logger } from '@/lib/logging/logger';
 import { ReadinessError } from '@/lib/errors/ReadinessError';
 import { checkDbReachable } from '@/dal/db/db.service';
+import { AppReadinessResponse } from '@/app/api/app/readyz/app_readines_response';
 
 const log = logger.with({ component: 'migrations.service' });
 
@@ -21,8 +22,8 @@ export async function checkDbMigrations(): Promise<MigrationDetails | null> {
     return lastMigration ?? null;
 }
 
-export async function checkReady() {
+export async function checkReady(): Promise<AppReadinessResponse> {
     await checkDbReachable();
     const migration = await checkDbMigrations();
-    return { ok: true as const, migration };
+    return { ok: true as const, migrationDetails: migration };
 }

--- a/dal/migrations/migrations.service.ts
+++ b/dal/migrations/migrations.service.ts
@@ -3,7 +3,7 @@ import { countPendingMigrations, getLastAppliedMigration } from '@/dal/migration
 import { logger } from '@/lib/logging/logger';
 import { ReadinessError } from '@/lib/errors/ReadinessError';
 import { checkDbReachable } from '@/dal/db/db.service';
-import { AppReadinessResponse } from '@/app/api/app/readyz/app_readines_response';
+import { AppReadinessResponse } from '@/app/api/app/readyz/route';
 
 const log = logger.with({ component: 'migrations.service' });
 

--- a/dal/migrations/migrations.service.ts
+++ b/dal/migrations/migrations.service.ts
@@ -2,6 +2,7 @@ import { MigrationDetails } from '@/dal/migrations/migrations.types';
 import { countPendingMigrations, getLastAppliedMigration } from '@/dal/migrations/migrations.repo';
 import { logger } from '@/lib/logging/logger';
 import { ReadinessError } from '@/lib/errors/ReadinessError';
+import { checkDbReachable } from '@/dal/db/db.service';
 
 const log = logger.with({ component: 'migrations.service' });
 
@@ -18,4 +19,10 @@ export async function checkDbMigrations(): Promise<MigrationDetails | null> {
     const lastMigration = await getLastAppliedMigration();
 
     return lastMigration ?? null;
+}
+
+export async function checkReady() {
+    await checkDbReachable();
+    const migration = await checkDbMigrations();
+    return { ok: true as const, migration };
 }

--- a/dal/migrations/migrations.types.ts
+++ b/dal/migrations/migrations.types.ts
@@ -6,3 +6,10 @@ export type LastMigration = {
     rolledBackAt: string | null;
     logs: string | null;
 };
+
+export type MigrationDetails = {
+    migrationName: string | null;
+    startedAt: Date | null;
+    finishedAt: Date | null;
+    appliedStepsCount: number | null;
+};

--- a/dal/migrations/migrations.types.ts
+++ b/dal/migrations/migrations.types.ts
@@ -1,0 +1,8 @@
+export type LastMigration = {
+    migrationName: string | null;
+    startedAt: string | null;
+    finishedAt: string | null;
+    appliedStepsCount: number | null;
+    rolledBackAt: string | null;
+    logs: string | null;
+};

--- a/dal/migrations/migrations.types.ts
+++ b/dal/migrations/migrations.types.ts
@@ -1,12 +1,3 @@
-export type LastMigration = {
-    migrationName: string | null;
-    startedAt: string | null;
-    finishedAt: string | null;
-    appliedStepsCount: number | null;
-    rolledBackAt: string | null;
-    logs: string | null;
-};
-
 export type MigrationDetails = {
     migrationName: string | null;
     startedAt: Date | null;

--- a/lib/errors/ReadinessError.ts
+++ b/lib/errors/ReadinessError.ts
@@ -1,0 +1,12 @@
+import { AppError } from '@/lib/errors/AppError';
+import { ReadinessReason } from '@/lib/errors/types';
+
+export class ReadinessError extends AppError {
+    constructor(
+        public readonly reason: ReadinessReason,
+        message: string,
+        public readonly details?: Record<string, unknown>
+    ) {
+        super(`readiness:${reason}_error`, message, 503, true);
+    }
+}

--- a/lib/errors/types.ts
+++ b/lib/errors/types.ts
@@ -1,3 +1,5 @@
 export interface ErrorWithCode extends Error {
     code?: number | string;
 }
+
+export type ReadinessReason = 'database' | 'migrations' | 'timeout';

--- a/lib/timeouts.ts
+++ b/lib/timeouts.ts
@@ -1,0 +1,3 @@
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    return Promise.race([promise, new Promise<T>((_, reject) => setTimeout(() => reject(new Error('timeout')), ms))]);
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "test:unit": "vitest run -c vitest.unit.config.ts --coverage",
         "test:integration": "vitest run -c vitest.integration.config.ts --coverage",
         "test:ui": "vitest run -c vitest.ui.config.ts --coverage",
-        "test:integration-local": "export RUN_WHOIS_INTEGRATION=1 && docker compose --env-file .env.test up -d db && bash -lc 'set -a; source .env.test; set +a; pnpm prisma migrate deploy && pnpm prisma generate && pnpm vitest run tests/integration'"
+        "test:integration-local": "export RUN_WHOIS_INTEGRATION=1 && docker compose --env-file .env.test up -d db && bash -lc 'set -a; source .env.test; set +a; pnpm prisma migrate reset --force && pnpm prisma generate && pnpm vitest run tests/integration'"
     },
     "dependencies": {
         "@prisma/adapter-pg": "^7.1.0",
@@ -31,7 +31,7 @@
         "dotenv": "^17.2.3",
         "framer-motion": "^12.23.26",
         "lucide-react": "^0.556.0",
-        "next": "16.0.10",
+        "next": "16.1.5",
         "next-themes": "^0.4.6",
         "pg": "^8.16.3",
         "react": "19.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^0.556.0
         version: 0.556.0(react@19.2.3)
       next:
-        specifier: 16.0.10
-        version: 16.0.10(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: 16.1.5
+        version: 16.1.5(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -696,56 +696,56 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@16.0.10':
-    resolution: {integrity: sha512-8tuaQkyDVgeONQ1MeT9Mkk8pQmZapMKFh5B+OrFUlG3rVmYTXcXlBetBgTurKXGaIZvkoqRT9JL5K3phXcgang==}
+  '@next/env@16.1.5':
+    resolution: {integrity: sha512-CRSCPJiSZoi4Pn69RYBDI9R7YK2g59vLexPQFXY0eyw+ILevIenCywzg+DqmlBik9zszEnw2HLFOUlLAcJbL7g==}
 
   '@next/eslint-plugin-next@16.0.8':
     resolution: {integrity: sha512-1miV0qXDcLUaOdHridVPCh4i39ElRIAraseVIbb3BEqyZ5ol9sPyjTP/GNTPV5rBxqxjF6/vv5zQTVbhiNaLqA==}
 
-  '@next/swc-darwin-arm64@16.0.10':
-    resolution: {integrity: sha512-4XgdKtdVsaflErz+B5XeG0T5PeXKDdruDf3CRpnhN+8UebNa5N2H58+3GDgpn/9GBurrQ1uWW768FfscwYkJRg==}
+  '@next/swc-darwin-arm64@16.1.5':
+    resolution: {integrity: sha512-eK7Wdm3Hjy/SCL7TevlH0C9chrpeOYWx2iR7guJDaz4zEQKWcS1IMVfMb9UKBFMg1XgzcPTYPIp1Vcpukkjg6Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.0.10':
-    resolution: {integrity: sha512-spbEObMvRKkQ3CkYVOME+ocPDFo5UqHb8EMTS78/0mQ+O1nqE8toHJVioZo4TvebATxgA8XMTHHrScPrn68OGw==}
+  '@next/swc-darwin-x64@16.1.5':
+    resolution: {integrity: sha512-foQscSHD1dCuxBmGkbIr6ScAUF6pRoDZP6czajyvmXPAOFNnQUJu2Os1SGELODjKp/ULa4fulnBWoHV3XdPLfA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.0.10':
-    resolution: {integrity: sha512-uQtWE3X0iGB8apTIskOMi2w/MKONrPOUCi5yLO+v3O8Mb5c7K4Q5KD1jvTpTF5gJKa3VH/ijKjKUq9O9UhwOYw==}
+  '@next/swc-linux-arm64-gnu@16.1.5':
+    resolution: {integrity: sha512-qNIb42o3C02ccIeSeKjacF3HXotGsxh/FMk/rSRmCzOVMtoWH88odn2uZqF8RLsSUWHcAqTgYmPD3pZ03L9ZAA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.0.10':
-    resolution: {integrity: sha512-llA+hiDTrYvyWI21Z0L1GiXwjQaanPVQQwru5peOgtooeJ8qx3tlqRV2P7uH2pKQaUfHxI/WVarvI5oYgGxaTw==}
+  '@next/swc-linux-arm64-musl@16.1.5':
+    resolution: {integrity: sha512-U+kBxGUY1xMAzDTXmuVMfhaWUZQAwzRaHJ/I6ihtR5SbTVUEaDRiEU9YMjy1obBWpdOBuk1bcm+tsmifYSygfw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.0.10':
-    resolution: {integrity: sha512-AK2q5H0+a9nsXbeZ3FZdMtbtu9jxW4R/NgzZ6+lrTm3d6Zb7jYrWcgjcpM1k8uuqlSy4xIyPR2YiuUr+wXsavA==}
+  '@next/swc-linux-x64-gnu@16.1.5':
+    resolution: {integrity: sha512-gq2UtoCpN7Ke/7tKaU7i/1L7eFLfhMbXjNghSv0MVGF1dmuoaPeEVDvkDuO/9LVa44h5gqpWeJ4mRRznjDv7LA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.0.10':
-    resolution: {integrity: sha512-1TDG9PDKivNw5550S111gsO4RGennLVl9cipPhtkXIFVwo31YZ73nEbLjNC8qG3SgTz/QZyYyaFYMeY4BKZR/g==}
+  '@next/swc-linux-x64-musl@16.1.5':
+    resolution: {integrity: sha512-bQWSE729PbXT6mMklWLf8dotislPle2L70E9q6iwETYEOt092GDn0c+TTNj26AjmeceSsC4ndyGsK5nKqHYXjQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.0.10':
-    resolution: {integrity: sha512-aEZIS4Hh32xdJQbHz121pyuVZniSNoqDVx1yIr2hy+ZwJGipeqnMZBJHyMxv2tiuAXGx6/xpTcQJ6btIiBjgmg==}
+  '@next/swc-win32-arm64-msvc@16.1.5':
+    resolution: {integrity: sha512-LZli0anutkIllMtTAWZlDqdfvjWX/ch8AFK5WgkNTvaqwlouiD1oHM+WW8RXMiL0+vAkAJyAGEzPPjO+hnrSNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.0.10':
-    resolution: {integrity: sha512-E+njfCoFLb01RAFEnGZn6ERoOqhK1Gl3Lfz1Kjnj0Ulfu7oJbuMyvBKNj/bw8XZnenHDASlygTjZICQW+rYW1Q==}
+  '@next/swc-win32-x64-msvc@16.1.5':
+    resolution: {integrity: sha512-7is37HJTNQGhjPpQbkKjKEboHYQnCgpVt/4rBrrln0D9nderNxZ8ZWs8w1fAtzUx7wEyYjQ+/13myFgFj6K2Ng==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2761,8 +2761,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.0.10:
-    resolution: {integrity: sha512-RtWh5PUgI+vxlV3HdR+IfWA1UUHu0+Ram/JBO4vWB54cVPentCD0e+lxyAYEsDTqGGMg7qpjhKh6dc6aW7W/sA==}
+  next@16.1.5:
+    resolution: {integrity: sha512-f+wE+NSbiQgh3DSAlTaw2FwY5yGdVViAtp8TotNQj4kk4Q8Bh1sC/aL9aH+Rg1YAVn18OYXsRDT7U/079jgP7w==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4126,34 +4126,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.0.10': {}
+  '@next/env@16.1.5': {}
 
   '@next/eslint-plugin-next@16.0.8':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.0.10':
+  '@next/swc-darwin-arm64@16.1.5':
     optional: true
 
-  '@next/swc-darwin-x64@16.0.10':
+  '@next/swc-darwin-x64@16.1.5':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.0.10':
+  '@next/swc-linux-arm64-gnu@16.1.5':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.0.10':
+  '@next/swc-linux-arm64-musl@16.1.5':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.0.10':
+  '@next/swc-linux-x64-gnu@16.1.5':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.0.10':
+  '@next/swc-linux-x64-musl@16.1.5':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.0.10':
+  '@next/swc-win32-arm64-msvc@16.1.5':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.0.10':
+  '@next/swc-win32-x64-msvc@16.1.5':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6295,24 +6295,25 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.0.10(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.5(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      '@next/env': 16.0.10
+      '@next/env': 16.1.5
       '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.9.7
       caniuse-lite: 1.0.30001760
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.0.10
-      '@next/swc-darwin-x64': 16.0.10
-      '@next/swc-linux-arm64-gnu': 16.0.10
-      '@next/swc-linux-arm64-musl': 16.0.10
-      '@next/swc-linux-x64-gnu': 16.0.10
-      '@next/swc-linux-x64-musl': 16.0.10
-      '@next/swc-win32-arm64-msvc': 16.0.10
-      '@next/swc-win32-x64-msvc': 16.0.10
+      '@next/swc-darwin-arm64': 16.1.5
+      '@next/swc-darwin-x64': 16.1.5
+      '@next/swc-linux-arm64-gnu': 16.1.5
+      '@next/swc-linux-arm64-musl': 16.1.5
+      '@next/swc-linux-x64-gnu': 16.1.5
+      '@next/swc-linux-x64-musl': 16.1.5
+      '@next/swc-win32-arm64-msvc': 16.1.5
+      '@next/swc-win32-x64-msvc': 16.1.5
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'

--- a/tests/integration/dal/db/db.repo.test.ts
+++ b/tests/integration/dal/db/db.repo.test.ts
@@ -1,0 +1,19 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { prisma } from '@/lib/prisma';
+import { pingDb } from '@/dal/db/db.repo';
+
+describe('Database repository integration tests', () => {
+    beforeAll(async () => {
+        await prisma.$connect();
+    });
+
+    afterAll(async () => {
+        await prisma.$disconnect();
+    });
+
+    describe('pingDb', () => {
+        it('Should resolve when the database is reachable', async () => {
+            await expect(pingDb()).resolves.toBeUndefined();
+        });
+    });
+});

--- a/tests/integration/dal/db/db.service.test.ts
+++ b/tests/integration/dal/db/db.service.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { prisma } from '@/lib/prisma';
 import { pingDb } from '@/dal/db/db.repo';
 import { checkDbReachable } from '@/dal/db/db.service';
@@ -13,6 +13,11 @@ describe('Database service integration tests', () => {
         await prisma.$disconnect();
     });
 
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
     describe('pingDb', () => {
         it('Should resolve when the database is reachable', async () => {
             await expect(pingDb()).resolves.toBeUndefined();
@@ -20,16 +25,31 @@ describe('Database service integration tests', () => {
     });
 
     describe('checkDbReachable', () => {
-        it('Should not throw error when the database is reachable', async () => {
+        it('Should not throw when the database is reachable', async () => {
             await expect(checkDbReachable()).resolves.toBeUndefined();
         });
 
         it('Should throw ReadinessError when database is not reachable', async () => {
-            const pingSpy = vi
-                .spyOn(await import('@/dal/db/db.repo'), 'pingDb')
-                .mockRejectedValueOnce(new Error('db down'));
+            const pingSpy = vi.spyOn(await import('@/dal/db/db.repo'), 'pingDb').mockRejectedValueOnce(
+                new Error('db down')
+            );
 
             await expect(checkDbReachable()).rejects.toBeInstanceOf(ReadinessError);
+
+            pingSpy.mockRestore();
+        });
+
+        it('Should throw ReadinessError when pingDb exceeds timeout', async () => {
+            vi.useFakeTimers();
+            const pingSpy = vi
+                .spyOn(await import('@/dal/db/db.repo'), 'pingDb')
+                .mockImplementationOnce(() => new Promise(() => undefined));
+
+            const promise = checkDbReachable(10);
+            const assertion = expect(promise).rejects.toBeInstanceOf(ReadinessError);
+            await vi.advanceTimersByTimeAsync(10);
+
+            await assertion;
 
             pingSpy.mockRestore();
         });

--- a/tests/integration/dal/db/db.service.test.ts
+++ b/tests/integration/dal/db/db.service.test.ts
@@ -1,0 +1,37 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { prisma } from '@/lib/prisma';
+import { pingDb } from '@/dal/db/db.repo';
+import { checkDbReachable } from '@/dal/db/db.service';
+import { ReadinessError } from '@/lib/errors/ReadinessError';
+
+describe('Database service integration tests', () => {
+    beforeAll(async () => {
+        await prisma.$connect();
+    });
+
+    afterAll(async () => {
+        await prisma.$disconnect();
+    });
+
+    describe('pingDb', () => {
+        it('Should resolve when the database is reachable', async () => {
+            await expect(pingDb()).resolves.toBeUndefined();
+        });
+    });
+
+    describe('checkDbReachable', () => {
+        it('Should not throw error when the database is reachable', async () => {
+            await expect(checkDbReachable()).resolves.toBeUndefined();
+        });
+
+        it('Should throw ReadinessError when database is not reachable', async () => {
+            const pingSpy = vi
+                .spyOn(await import('@/dal/db/db.repo'), 'pingDb')
+                .mockRejectedValueOnce(new Error('db down'));
+
+            await expect(checkDbReachable()).rejects.toBeInstanceOf(ReadinessError);
+
+            pingSpy.mockRestore();
+        });
+    });
+});

--- a/tests/integration/dal/links/links.repo.test.ts
+++ b/tests/integration/dal/links/links.repo.test.ts
@@ -497,35 +497,6 @@ describe('Link Repository - Integration Tests', () => {
                     // Should have triggered 3 enrichment jobs
                     expect(upsertDomainEnrichmentJob).toHaveBeenCalledTimes(3);
                 });
-
-                it('Should handle concurrent link creation with different domains', async () => {
-                    // Arrange
-                    const hostnames = ['example.com', 'google.com', 'github.com'];
-                    let callCount = 0;
-
-                    (normalizeHostnameFromUrl as Mock).mockImplementation(() => {
-                        const hostname = hostnames[callCount % hostnames.length];
-                        callCount++;
-                        return hostname;
-                    });
-
-                    // Act
-                    const slugs = ['link-a', 'link-b', 'link-c', 'link-d', 'link-e'];
-                    const promises = slugs.map((slug, index) =>
-                        createLink({
-                            slug,
-                            targetUrl: `https://${hostnames[index % hostnames.length]}/${slug}`,
-                            ownerId: null,
-                        })
-                    );
-
-                    await Promise.all(promises);
-
-                    // Assert
-                    const domains = await prisma.domain.findMany();
-                    expect(domains).toHaveLength(3); // example.com, google.com, github.com
-                    expect(upsertDomainEnrichmentJob).toHaveBeenCalledTimes(5);
-                });
             });
 
             describe('Database constraints and data integrity', () => {

--- a/tests/integration/dal/migrations/migrations.repo.test.ts
+++ b/tests/integration/dal/migrations/migrations.repo.test.ts
@@ -1,0 +1,153 @@
+import { describe, beforeAll, beforeEach, it, expect, afterAll } from 'vitest';
+import { prisma } from '@/lib/prisma';
+import { migrationsTableExists } from '@/dal/migrations/migrations.repo';
+import { PrismaClient } from '@/generated/prisma/client';
+
+describe('Database migrations repository integration tests', () => {
+    let testPrisma: PrismaClient;
+
+    beforeAll(async () => {
+        testPrisma = prisma;
+        await testPrisma.$connect();
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations CASCADE`;
+    });
+
+    afterAll(async () => {
+        // Cleanup final
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations CASCADE`;
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS test_table CASCADE`;
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS _PRISMA_MIGRATIONS CASCADE`;
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS prisma_migrations CASCADE`;
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations_test CASCADE`;
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations_ CASCADE`;
+        await testPrisma.$executeRaw`DROP SCHEMA IF EXISTS test_schema CASCADE`;
+        await testPrisma.$disconnect();
+    });
+
+    beforeEach(async () => {
+        await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations CASCADE`;
+    });
+
+    describe('When migrations table does not exist', () => {
+        it('Should return false when table does not exist', async () => {
+            const result = await migrationsTableExists();
+            expect(result).toBe(false);
+        });
+
+        it('Should return false even after other operations', async () => {
+            await testPrisma.$executeRaw`CREATE TABLE IF NOT EXISTS test_table (id SERIAL PRIMARY KEY)`;
+
+            const result = await migrationsTableExists();
+            expect(result).toBe(false);
+
+            await testPrisma.$executeRaw`DROP TABLE IF EXISTS test_table`;
+        });
+    });
+
+    describe('When migrations table exists', () => {
+        beforeEach(async () => {
+            await testPrisma.$executeRaw`
+                CREATE TABLE _prisma_migrations (
+                    id VARCHAR(36) PRIMARY KEY,
+                    checksum VARCHAR(64) NOT NULL,
+                    finished_at TIMESTAMPTZ,
+                    migration_name VARCHAR(255) NOT NULL,
+                    logs TEXT,
+                    rolled_back_at TIMESTAMPTZ,
+                    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    applied_steps_count INTEGER NOT NULL DEFAULT 0
+                )
+            `;
+        });
+
+        it('Should return true when table exists with correct schema', async () => {
+            const result = await migrationsTableExists();
+            expect(result).toBe(true);
+        });
+
+        it('Should return true even with empty table', async () => {
+            await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+            await testPrisma.$executeRaw`
+                CREATE TABLE _prisma_migrations (
+                    id VARCHAR(36) PRIMARY KEY
+                )
+            `;
+
+            const result = await migrationsTableExists();
+            expect(result).toBe(true);
+        });
+    });
+
+    describe('Edge cases and error handling', () => {
+        it('Should handle case sensitivity correctly', async () => {
+            await testPrisma.$executeRaw`CREATE TABLE "_PRISMA_MIGRATIONS" (id SERIAL PRIMARY KEY)`;
+
+            const result = await migrationsTableExists();
+            expect(result).toBe(false);
+
+            await testPrisma.$executeRaw`DROP TABLE IF EXISTS "_PRISMA_MIGRATIONS"`;
+        });
+
+        it('Should work correctly after table is dropped and recreated', async () => {
+            await testPrisma.$executeRaw`
+                CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)
+            `;
+
+            expect(await migrationsTableExists()).toBe(true);
+
+            await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+            expect(await migrationsTableExists()).toBe(false);
+
+            await testPrisma.$executeRaw`
+                CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)
+            `;
+            expect(await migrationsTableExists()).toBe(true);
+        });
+
+        it('Should handle concurrent calls correctly', async () => {
+            const promises = Array(5)
+                .fill(null)
+                .map(() => migrationsTableExists());
+            const results = await Promise.all(promises);
+
+            results.forEach((result) => {
+                expect(result).toBe(false);
+            });
+        });
+    });
+
+    describe('Database schema specific tests', () => {
+        it('Should only check public schema by default', async () => {
+            await testPrisma.$executeRaw`CREATE SCHEMA IF NOT EXISTS test_schema`;
+            await testPrisma.$executeRaw`
+                CREATE TABLE test_schema._prisma_migrations (id VARCHAR(36) PRIMARY KEY)
+            `;
+
+            const result = await migrationsTableExists();
+            expect(result).toBe(false);
+
+            await testPrisma.$executeRaw`DROP SCHEMA IF EXISTS test_schema CASCADE`;
+        });
+
+        it('Should ignore tables with similar names', async () => {
+            await testPrisma.$executeRaw`CREATE TABLE prisma_migrations (id SERIAL PRIMARY KEY)`;
+            await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations_test (id SERIAL PRIMARY KEY)`;
+            await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations_ (id SERIAL PRIMARY KEY)`;
+
+            const result = await migrationsTableExists();
+            expect(result).toBe(false);
+
+            await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)`;
+            const newResult = await migrationsTableExists();
+            expect(newResult).toBe(true);
+
+            await testPrisma.$executeRaw`
+                DROP TABLE IF EXISTS 
+                    prisma_migrations, 
+                    _prisma_migrations_test, 
+                    _prisma_migrations_, 
+                    _prisma_migrations
+            `;
+        });
+    });
+});

--- a/tests/integration/dal/migrations/migrations.repo.test.ts
+++ b/tests/integration/dal/migrations/migrations.repo.test.ts
@@ -1,6 +1,10 @@
 import { describe, beforeAll, beforeEach, it, expect, afterAll } from 'vitest';
 import { prisma } from '@/lib/prisma';
-import { migrationsTableExists } from '@/dal/migrations/migrations.repo';
+import {
+    countAppliedMigrations,
+    countPendingMigrations,
+    migrationsTableExists,
+} from '@/dal/migrations/migrations.repo';
 import { PrismaClient } from '@/generated/prisma/client';
 
 describe('Database migrations repository integration tests', () => {
@@ -28,25 +32,26 @@ describe('Database migrations repository integration tests', () => {
         await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations CASCADE`;
     });
 
-    describe('When migrations table does not exist', () => {
-        it('Should return false when table does not exist', async () => {
-            const result = await migrationsTableExists();
-            expect(result).toBe(false);
+    describe('Migration table existence check', () => {
+        describe('When migrations table does not exist', () => {
+            it('Should return false when table does not exist', async () => {
+                const result = await migrationsTableExists();
+                expect(result).toBe(false);
+            });
+
+            it('Should return false even after other operations', async () => {
+                await testPrisma.$executeRaw`CREATE TABLE IF NOT EXISTS test_table (id SERIAL PRIMARY KEY)`;
+
+                const result = await migrationsTableExists();
+                expect(result).toBe(false);
+
+                await testPrisma.$executeRaw`DROP TABLE IF EXISTS test_table`;
+            });
         });
 
-        it('Should return false even after other operations', async () => {
-            await testPrisma.$executeRaw`CREATE TABLE IF NOT EXISTS test_table (id SERIAL PRIMARY KEY)`;
-
-            const result = await migrationsTableExists();
-            expect(result).toBe(false);
-
-            await testPrisma.$executeRaw`DROP TABLE IF EXISTS test_table`;
-        });
-    });
-
-    describe('When migrations table exists', () => {
-        beforeEach(async () => {
-            await testPrisma.$executeRaw`
+        describe('When migrations table exists', () => {
+            beforeEach(async () => {
+                await testPrisma.$executeRaw`
                 CREATE TABLE _prisma_migrations (
                     id VARCHAR(36) PRIMARY KEY,
                     checksum VARCHAR(64) NOT NULL,
@@ -58,96 +63,568 @@ describe('Database migrations repository integration tests', () => {
                     applied_steps_count INTEGER NOT NULL DEFAULT 0
                 )
             `;
-        });
+            });
 
-        it('Should return true when table exists with correct schema', async () => {
-            const result = await migrationsTableExists();
-            expect(result).toBe(true);
-        });
+            it('Should return true when table exists with correct schema', async () => {
+                const result = await migrationsTableExists();
+                expect(result).toBe(true);
+            });
 
-        it('Should return true even with empty table', async () => {
-            await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
-            await testPrisma.$executeRaw`
+            it('Should return true even with empty table', async () => {
+                await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+                await testPrisma.$executeRaw`
                 CREATE TABLE _prisma_migrations (
                     id VARCHAR(36) PRIMARY KEY
                 )
             `;
 
-            const result = await migrationsTableExists();
-            expect(result).toBe(true);
-        });
-    });
-
-    describe('Edge cases and error handling', () => {
-        it('Should handle case sensitivity correctly', async () => {
-            await testPrisma.$executeRaw`CREATE TABLE "_PRISMA_MIGRATIONS" (id SERIAL PRIMARY KEY)`;
-
-            const result = await migrationsTableExists();
-            expect(result).toBe(false);
-
-            await testPrisma.$executeRaw`DROP TABLE IF EXISTS "_PRISMA_MIGRATIONS"`;
-        });
-
-        it('Should work correctly after table is dropped and recreated', async () => {
-            await testPrisma.$executeRaw`
-                CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)
-            `;
-
-            expect(await migrationsTableExists()).toBe(true);
-
-            await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
-            expect(await migrationsTableExists()).toBe(false);
-
-            await testPrisma.$executeRaw`
-                CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)
-            `;
-            expect(await migrationsTableExists()).toBe(true);
-        });
-
-        it('Should handle concurrent calls correctly', async () => {
-            const promises = Array(5)
-                .fill(null)
-                .map(() => migrationsTableExists());
-            const results = await Promise.all(promises);
-
-            results.forEach((result) => {
-                expect(result).toBe(false);
+                const result = await migrationsTableExists();
+                expect(result).toBe(true);
             });
         });
-    });
 
-    describe('Database schema specific tests', () => {
-        it('Should only check public schema by default', async () => {
-            await testPrisma.$executeRaw`CREATE SCHEMA IF NOT EXISTS test_schema`;
-            await testPrisma.$executeRaw`
+        describe('Edge cases and error handling', () => {
+            it('Should handle case sensitivity correctly', async () => {
+                await testPrisma.$executeRaw`CREATE TABLE "_PRISMA_MIGRATIONS" (id SERIAL PRIMARY KEY)`;
+
+                const result = await migrationsTableExists();
+                expect(result).toBe(false);
+
+                await testPrisma.$executeRaw`DROP TABLE IF EXISTS "_PRISMA_MIGRATIONS"`;
+            });
+
+            it('Should work correctly after table is dropped and recreated', async () => {
+                await testPrisma.$executeRaw`
+                CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)
+            `;
+
+                expect(await migrationsTableExists()).toBe(true);
+
+                await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+                expect(await migrationsTableExists()).toBe(false);
+
+                await testPrisma.$executeRaw`
+                CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)
+            `;
+                expect(await migrationsTableExists()).toBe(true);
+            });
+
+            it('Should handle concurrent calls correctly', async () => {
+                const promises = Array(5)
+                    .fill(null)
+                    .map(() => migrationsTableExists());
+                const results = await Promise.all(promises);
+
+                results.forEach((result) => {
+                    expect(result).toBe(false);
+                });
+            });
+        });
+
+        describe('Database schema specific tests', () => {
+            it('Should only check public schema by default', async () => {
+                await testPrisma.$executeRaw`CREATE SCHEMA IF NOT EXISTS test_schema`;
+                await testPrisma.$executeRaw`
                 CREATE TABLE test_schema._prisma_migrations (id VARCHAR(36) PRIMARY KEY)
             `;
 
-            const result = await migrationsTableExists();
-            expect(result).toBe(false);
+                const result = await migrationsTableExists();
+                expect(result).toBe(false);
 
-            await testPrisma.$executeRaw`DROP SCHEMA IF EXISTS test_schema CASCADE`;
-        });
+                await testPrisma.$executeRaw`DROP SCHEMA IF EXISTS test_schema CASCADE`;
+            });
 
-        it('Should ignore tables with similar names', async () => {
-            await testPrisma.$executeRaw`CREATE TABLE prisma_migrations (id SERIAL PRIMARY KEY)`;
-            await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations_test (id SERIAL PRIMARY KEY)`;
-            await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations_ (id SERIAL PRIMARY KEY)`;
+            it('Should ignore tables with similar names', async () => {
+                await testPrisma.$executeRaw`CREATE TABLE prisma_migrations (id SERIAL PRIMARY KEY)`;
+                await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations_test (id SERIAL PRIMARY KEY)`;
+                await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations_ (id SERIAL PRIMARY KEY)`;
 
-            const result = await migrationsTableExists();
-            expect(result).toBe(false);
+                const result = await migrationsTableExists();
+                expect(result).toBe(false);
 
-            await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)`;
-            const newResult = await migrationsTableExists();
-            expect(newResult).toBe(true);
+                await testPrisma.$executeRaw`CREATE TABLE _prisma_migrations (id VARCHAR(36) PRIMARY KEY)`;
+                const newResult = await migrationsTableExists();
+                expect(newResult).toBe(true);
 
-            await testPrisma.$executeRaw`
+                await testPrisma.$executeRaw`
                 DROP TABLE IF EXISTS 
                     prisma_migrations, 
                     _prisma_migrations_test, 
                     _prisma_migrations_, 
                     _prisma_migrations
             `;
+            });
+        });
+    });
+
+    describe('Count pending migrations', () => {
+        beforeEach(async () => {
+            await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations`;
+            await testPrisma.$executeRaw`
+            CREATE TABLE _prisma_migrations (
+                id VARCHAR(36) PRIMARY KEY,
+                checksum VARCHAR(64) NOT NULL,
+                finished_at TIMESTAMPTZ,
+                migration_name VARCHAR(255) NOT NULL,
+                logs TEXT,
+                rolled_back_at TIMESTAMPTZ,
+                started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                applied_steps_count INTEGER NOT NULL DEFAULT 0
+            )
+        `;
+        });
+
+        describe('When table is empty', () => {
+            it('Should return 0 when there are no migrations', async () => {
+                const result = await countPendingMigrations();
+                expect(result).toBe(0);
+            });
+
+            it('Should return 0 even with other tables present', async () => {
+                await testPrisma.$executeRaw`CREATE TABLE test_table (id SERIAL PRIMARY KEY)`;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(0);
+
+                await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+            });
+        });
+
+        describe('When there are completed migrations', () => {
+            it('Should return 0 when all migrations are finished', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), 1),
+                    ('uuid3', 'checksum3', '003_add_posts', NOW(), NOW(), 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(0);
+            });
+
+            it('Should return 0 when migrations are rolled back', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(0);
+            });
+
+            it('Should return 0 when migrations have both finished_at and rolled_back_at', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), NOW(), 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(0);
+            });
+        });
+
+        describe('When there are pending migrations', () => {
+            it('Should count migrations with null finished_at and null rolled_back_at', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(2);
+            });
+
+            it('Should count only pending migrations among mixed status', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NULL, NOW(), 1), -- finished
+                    ('uuid2', 'checksum2', '002_add_users', NULL, NOW(), NOW(), 1), -- rolled back
+                    ('uuid3', 'checksum3', '003_add_posts', NULL, NULL, NOW(), 1), -- pending
+                    ('uuid4', 'checksum4', '004_add_comments', NULL, NULL, NOW(), 1), -- pending
+                    ('uuid5', 'checksum5', '005_add_likes', NOW(), NOW(), NOW(), 1) -- both finished and rolled back
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(2); // Doar uuid3 și uuid4 sunt pending
+            });
+
+            it('Should handle large number of pending migrations', async () => {
+                const migrations = Array.from({ length: 100 }, (_, i) => ({
+                    id: `uuid${i + 1}`,
+                    checksum: `checksum${i + 1}`,
+                    name: `00${String(i + 1).padStart(3, '0')}_migration`,
+                    started_at: new Date(),
+                }));
+
+                for (const migration of migrations) {
+                    await testPrisma.$executeRaw`
+                    INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                    VALUES (${migration.id}, ${migration.checksum}, ${migration.name}, ${migration.started_at}, 1)
+                `;
+                }
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(100);
+            });
+        });
+
+        describe('Edge cases and data types', () => {
+            it('Should handle migrations with started_at in the future', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW() + INTERVAL '1 day', 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(1);
+            });
+
+            it('Should handle migrations with NULL started_at (though unlikely)', async () => {
+                await testPrisma.$executeRaw`
+                ALTER TABLE _prisma_migrations ALTER COLUMN started_at DROP NOT NULL
+            `;
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, applied_steps_count)
+                VALUES ('uuid1', 'checksum1', '001_init', 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(1);
+            });
+
+            it('Should return 0 when table does not exist', async () => {
+                await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(0);
+            });
+        });
+
+        describe('Concurrent operations', () => {
+            it('Should provide consistent count during concurrent inserts', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), 1)
+            `;
+
+                const initialCount = await countPendingMigrations();
+                expect(initialCount).toBe(2);
+
+                const insertPromises = Array.from(
+                    { length: 3 },
+                    (_, i) =>
+                        testPrisma.$executeRaw`
+                    INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                    VALUES (${`new-uuid${i}`}, ${`new-checksum${i}`}, ${`00${i + 3}_migration`}, NOW(), 1)
+                `
+                );
+
+                const countPromises = Array.from({ length: 5 }, () => countPendingMigrations());
+                await Promise.all([...insertPromises, ...countPromises]);
+
+                const finalCount = await countPendingMigrations();
+                expect(finalCount).toBe(5);
+            });
+        });
+
+        describe('Data validation', () => {
+            it('Should handle special characters in migration names', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init_with-dashes', NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_underscores_and_CAPITALS', NOW(), 1),
+                    ('uuid3', 'checksum3', '003_êmîgrâtïøn_ñámèß', NOW(), 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(3);
+            });
+
+            it('Should handle different timestamp precisions', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', '2024-01-01 10:00:00', 1),
+                    ('uuid2', 'checksum2', '002_add_users', '2024-01-01 10:00:00.123456', 1),
+                    ('uuid3', 'checksum3', '003_add_posts', '2024-01-01 10:00:00.000001', 1)
+            `;
+
+                const result = await countPendingMigrations();
+                expect(result).toBe(3);
+            });
+        });
+    });
+
+    describe('Count applied migrations function', () => {
+        beforeEach(async () => {
+            await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations`;
+            await testPrisma.$executeRaw`
+            CREATE TABLE _prisma_migrations (
+                id VARCHAR(36) PRIMARY KEY,
+                checksum VARCHAR(64) NOT NULL,
+                finished_at TIMESTAMPTZ,
+                migration_name VARCHAR(255) NOT NULL,
+                logs TEXT,
+                rolled_back_at TIMESTAMPTZ,
+                started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                applied_steps_count INTEGER NOT NULL DEFAULT 0
+            )
+        `;
+        });
+
+        describe('When table does not exist', () => {
+            it('Should return 0 when migrations table does not exist', async () => {
+                await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(0);
+            });
+
+            it('Should return 0 even with other tables present', async () => {
+                await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+                await testPrisma.$executeRaw`CREATE TABLE IF NOT EXISTS test_table (id SERIAL PRIMARY KEY)`;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(0);
+
+                await testPrisma.$executeRaw`DROP TABLE "test_table"`;
+            });
+        });
+
+        describe('When table is empty', () => {
+            it('Should return 0 when there are no migrations in the table', async () => {
+                const result = await countAppliedMigrations();
+                expect(result).toBe(0);
+            });
+        });
+
+        describe('When there are only pending migrations', () => {
+            it('Should return 0 when all migrations are pending (no finished_at)', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), 1),
+                    ('uuid3', 'checksum3', '003_add_posts', NOW(), 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(0);
+            });
+
+            it('Should return 0 when migrations have NULL finished_at', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NULL, NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NULL, NOW(), 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(0);
+            });
+        });
+
+        describe('When there are applied migrations', () => {
+            it('Should count migrations with finished_at not null and rolled_back_at null', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(2);
+            });
+
+            it('Should count only applied migrations among mixed status', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NULL, NOW(), 1), -- applied
+                    ('uuid2', 'checksum2', '002_add_users', NULL, NULL, NOW(), 1), -- pending
+                    ('uuid3', 'checksum3', '003_add_posts', NOW(), NULL, NOW(), 1), -- applied
+                    ('uuid4', 'checksum4', '004_add_comments', NULL, NOW(), NOW(), 1), -- rolled back
+                    ('uuid5', 'checksum5', '005_add_likes', NOW(), NOW(), NOW(), 1) -- rolled back (even with finished_at)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(2);
+            });
+
+            it('Should handle migrations with different finished_at timestamps', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', '2024-01-01 10:00:00', '2024-01-01 09:00:00', 1),
+                    ('uuid2', 'checksum2', '002_add_users', '2024-01-02 11:00:00', '2024-01-02 10:00:00', 1),
+                    ('uuid3', 'checksum3', '003_add_posts', '2024-01-03 12:00:00', '2024-01-03 11:00:00', 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(3);
+            });
+        });
+
+        describe('When there are rolled back migrations', () => {
+            it('Should not count migrations with rolled_back_at not null', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(0);
+            });
+
+            it('Should not count migrations with both finished_at and rolled_back_at', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), NOW(), 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(0);
+            });
+        });
+
+        describe('Edge cases and data validation', () => {
+            it('Should handle large number of applied migrations', async () => {
+                const migrations = Array.from({ length: 100 }, (_, i) => ({
+                    id: `uuid${i + 1}`,
+                    checksum: `checksum${i + 1}`,
+                    name: `00${String(i + 1).padStart(3, '0')}_migration`,
+                    started_at: new Date(),
+                    finished_at: new Date(Date.now() + 1000),
+                }));
+
+                for (const migration of migrations) {
+                    await testPrisma.$executeRaw`
+                    INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, finished_at, applied_steps_count)
+                    VALUES (${migration.id}, ${migration.checksum}, ${migration.name}, ${migration.started_at}, ${migration.finished_at}, 1)
+                `;
+                }
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(100);
+            });
+
+            it('Should handle migrations with future finished_at dates', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW() + INTERVAL '1 day', NOW(), 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(1);
+            });
+
+            it('Should handle edge case where started_at is after finished_at', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', '2024-01-01 10:00:00', '2024-01-01 11:00:00', 1)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(1);
+            });
+
+            it('Should handle migrations with zero applied_steps_count', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 0)
+            `;
+
+                const result = await countAppliedMigrations();
+                expect(result).toBe(1);
+            });
+        });
+
+        describe('Concurrent operations', () => {
+            it('Should provide consistent count during concurrent operations', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), 1)
+            `;
+
+                const initialCount = await countAppliedMigrations();
+                expect(initialCount).toBe(2);
+
+                const insertPromises = Array.from(
+                    { length: 3 },
+                    (_, i) =>
+                        testPrisma.$executeRaw`
+                    INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                    VALUES (${`new-uuid${i}`}, ${`new-checksum${i}`}, ${`00${i + 3}_migration`}, NOW(), NOW(), 1)
+                `
+                );
+
+                const countPromises = Array.from({ length: 5 }, () => countAppliedMigrations());
+
+                await Promise.all([...insertPromises, ...countPromises]);
+
+                const finalCount = await countAppliedMigrations();
+                expect(finalCount).toBe(5);
+            });
+        });
+
+        describe('Data consistency', () => {
+            it('Should return consistent results with multiple calls', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NULL, NOW(), 1),
+                    ('uuid3', 'checksum3', '003_add_posts', NOW(), NOW(), 1)
+            `;
+
+                const results = await Promise.all([
+                    countAppliedMigrations(),
+                    countAppliedMigrations(),
+                    countAppliedMigrations(),
+                ]);
+
+                results.forEach((result) => {
+                    expect(result).toBe(2);
+                });
+
+                const totalMigrations = 3;
+                await countPendingMigrations();
+                await countAppliedMigrations();
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, rolled_back_at, started_at, applied_steps_count)
+                VALUES ('uuid4', 'checksum4', '004_rollback', NOW(), NOW(), 1)
+            `;
+
+                await countPendingMigrations();
+                const newAppliedCount = await countAppliedMigrations();
+
+                expect(newAppliedCount).toBeLessThanOrEqual(totalMigrations + 1);
+            });
         });
     });
 });

--- a/tests/integration/dal/migrations/migrations.repo.test.ts
+++ b/tests/integration/dal/migrations/migrations.repo.test.ts
@@ -3,6 +3,7 @@ import { prisma } from '@/lib/prisma';
 import {
     countAppliedMigrations,
     countPendingMigrations,
+    getLastAppliedMigration,
     migrationsTableExists,
 } from '@/dal/migrations/migrations.repo';
 import { PrismaClient } from '@/generated/prisma/client';
@@ -368,7 +369,7 @@ describe('Database migrations repository integration tests', () => {
         });
     });
 
-    describe('Count applied migrations function', () => {
+    describe('Count applied migrations', () => {
         beforeEach(async () => {
             await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations`;
             await testPrisma.$executeRaw`
@@ -624,6 +625,285 @@ describe('Database migrations repository integration tests', () => {
                 const newAppliedCount = await countAppliedMigrations();
 
                 expect(newAppliedCount).toBeLessThanOrEqual(totalMigrations + 1);
+            });
+        });
+    });
+
+    describe('Get last applied migration', () => {
+        beforeEach(async () => {
+            await testPrisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations`;
+            await testPrisma.$executeRaw`
+            CREATE TABLE _prisma_migrations (
+                id VARCHAR(36) PRIMARY KEY,
+                checksum VARCHAR(64) NOT NULL,
+                finished_at TIMESTAMPTZ,
+                migration_name VARCHAR(255) NOT NULL,
+                logs TEXT,
+                rolled_back_at TIMESTAMPTZ,
+                started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                applied_steps_count INTEGER NOT NULL DEFAULT 0
+            )
+        `;
+        });
+
+        describe('When table does not exist', () => {
+            it('Should return null when migrations table does not exist', async () => {
+                await testPrisma.$executeRaw`DROP TABLE _prisma_migrations`;
+
+                const result = await getLastAppliedMigration();
+                expect(result).toBeNull();
+            });
+        });
+
+        describe('When table is empty', () => {
+            it('Should return null when there are no migrations in the table', async () => {
+                const result = await getLastAppliedMigration();
+                expect(result).toBeNull();
+            });
+        });
+
+        describe('When there are no applied migrations', () => {
+            it('Should return null when all migrations are pending', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), 1),
+                    ('uuid3', 'checksum3', '003_add_posts', NOW(), 1)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).toBeNull();
+            });
+
+            it('Should return null when all migrations are rolled back', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), 1)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).toBeNull();
+            });
+
+            it('Should return null when migrations have both finished_at and rolled_back_at', async () => {
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW(), NOW(), NOW(), 1),
+                    ('uuid2', 'checksum2', '002_add_users', NOW(), NOW(), NOW(), 1)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).toBeNull();
+            });
+        });
+
+        describe('When there are applied migrations', () => {
+            it('Should return the most recently finished migration', async () => {
+                const now = new Date();
+                const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+                const twoDaysAgo = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', ${twoDaysAgo}, ${twoDaysAgo}, 1),
+                    ('uuid2', 'checksum2', '002_add_users', ${yesterday}, ${yesterday}, 1),
+                    ('uuid3', 'checksum3', '003_add_posts', ${now}, ${now}, 1)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).not.toBeNull();
+                expect(result!.migrationName).toBe('003_add_posts');
+                expect(result!.finishedAt).toEqual(now);
+                expect(result!.startedAt).toEqual(now);
+                expect(result!.appliedStepsCount).toBe(1);
+            });
+
+            it('Should ignore pending migrations when determining the last applied one', async () => {
+                const now = new Date();
+                const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', ${yesterday}, ${yesterday}, 1),
+                    ('uuid2', 'checksum2', '002_add_users', ${now}, ${now}, 1),
+                    ('uuid3', 'checksum3', '003_add_posts', NULL, ${now}, 1) -- pending
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).not.toBeNull();
+                expect(result!.migrationName).toBe('002_add_users');
+            });
+
+            it('Should ignore rolled back migrations when determining the last applied one', async () => {
+                const now = new Date();
+                const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', ${yesterday}, ${yesterday}, ${yesterday}, 1), -- rolled back
+                    ('uuid2', 'checksum2', '002_add_users', ${now}, NULL, ${now}, 1), -- applied
+                    ('uuid3', 'checksum3', '003_add_posts', ${now}, ${now}, ${now}, 1) -- rolled back
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).not.toBeNull();
+                expect(result!.migrationName).toBe('002_add_users');
+            });
+
+            it('Should handle migrations with the exact same finished_at timestamp', async () => {
+                const timestamp = new Date('2024-01-01T10:00:00Z');
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', ${timestamp}, ${timestamp}, 1),
+                    ('uuid2', 'checksum2', '002_add_users', ${timestamp}, ${timestamp}, 1),
+                    ('uuid3', 'checksum3', '003_add_posts', ${timestamp}, ${timestamp}, 1)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).not.toBeNull();
+                // Dacă toate au același finished_at, LIMIT 1 va returna unul arbitrar
+                // Testăm că returnează ceva valid
+                expect(['001_init', '002_add_users', '003_add_posts']).toContain(result!.migrationName);
+                expect(result!.finishedAt).toEqual(timestamp);
+            });
+        });
+
+        describe('Edge cases and data validation', () => {
+            it('Should return correct data structure', async () => {
+                const now = new Date();
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', ${now}, ${now}, 5)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).toEqual({
+                    migrationName: '001_init',
+                    startedAt: now,
+                    finishedAt: now,
+                    appliedStepsCount: 5,
+                });
+            });
+
+            it('Should handle migrations with special characters in names', async () => {
+                const now = new Date();
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init-with-dashes', ${now}, ${now}, 1),
+                    ('uuid2', 'checksum2', '002_add_underscores_and_CAPITALS', ${now}, ${now}, 1),
+                    ('uuid3', 'checksum3', '003_êmîgrâtïøn_ñámèß', ${now}, ${now}, 1)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).not.toBeNull();
+                expect(result!.migrationName).toBeOneOf([
+                    '001_init-with-dashes',
+                    '002_add_underscores_and_CAPITALS',
+                    '003_êmîgrâtïøn_ñámèß',
+                ]);
+            });
+
+            it('Should handle migrations with different applied_steps_count values', async () => {
+                const now = new Date();
+
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', NOW() - INTERVAL '2 hours', NOW() - INTERVAL '3 hours', 3),
+                    ('uuid2', 'checksum2', '002_add_users', NOW() - INTERVAL '1 hour', NOW() - INTERVAL '2 hours', 0),
+                    ('uuid3', 'checksum3', '003_add_posts', ${now}, ${now}, 15)
+            `;
+
+                const result = await getLastAppliedMigration();
+                expect(result).not.toBeNull();
+                expect(result!.migrationName).toBe('003_add_posts');
+                expect(result!.appliedStepsCount).toBe(15);
+            });
+        });
+
+        describe('Concurrent operations', () => {
+            it('Should provide consistent result during concurrent inserts', async () => {
+                // Adaugă câteva migrări aplicat inițiale
+                const initialTime = new Date('2024-01-01T10:00:00Z');
+                await testPrisma.$executeRaw`
+                INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                VALUES 
+                    ('uuid1', 'checksum1', '001_init', ${initialTime}, ${initialTime}, 1),
+                    ('uuid2', 'checksum2', '002_add_users', ${initialTime}, ${initialTime}, 1)
+            `;
+
+                const initialResult = await getLastAppliedMigration();
+                expect(initialResult).not.toBeNull();
+
+                // Adaugă concurrent mai multe migrări
+                const laterTime = new Date('2024-01-01T11:00:00Z');
+                const insertPromises = Array.from(
+                    { length: 3 },
+                    (_, i) =>
+                        testPrisma.$executeRaw`
+                    INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count)
+                    VALUES (${`new-uuid${i}`}, ${`new-checksum${i}`}, ${`00${i + 3}_migration`}, ${laterTime}, ${laterTime}, 1)
+                `
+                );
+
+                const readPromises = Array.from({ length: 5 }, () => getLastAppliedMigration());
+
+                await Promise.all([...insertPromises, ...readPromises]);
+
+                const finalResult = await getLastAppliedMigration();
+                expect(finalResult).not.toBeNull();
+                expect(finalResult!.migrationName).toMatch(/00[345]_migration/);
+            });
+        });
+
+        describe('Performance considerations', () => {
+            it('Should handle large number of migrations efficiently', async () => {
+                const migrations = Array.from({ length: 1000 }, (_, i) => {
+                    const migrationNumber = i + 1;
+                    return {
+                        id: `uuid${migrationNumber}`,
+                        checksum: `checksum${migrationNumber}`,
+                        name: `${String(migrationNumber).padStart(4, '0')}_migration`, // padStart(4, '0')
+                        started_at: new Date(Date.now() - (1000 - i) * 1000),
+                        finished_at: new Date(Date.now() - (1000 - i) * 1000 + 50000),
+                    };
+                });
+
+                for (let i = 0; i < migrations.length; i += 100) {
+                    const batch = migrations.slice(i, i + 100);
+                    const values = batch
+                        .map(
+                            (m) =>
+                                `('${m.id}', '${m.checksum}', '${m.name}', '${m.finished_at.toISOString()}', '${m.started_at.toISOString()}', 1)`
+                        )
+                        .join(', ');
+
+                    await testPrisma.$executeRawUnsafe(`
+                        INSERT INTO _prisma_migrations (id, checksum, migration_name, finished_at, started_at, applied_steps_count) VALUES ${values}
+                    `);
+                }
+
+                const startTime = Date.now();
+                const result = await getLastAppliedMigration();
+                const endTime = Date.now();
+
+                expect(result).not.toBeNull();
+                expect(result!.migrationName).toBe('1000_migration'); // Fără leading zeros
+
+                expect(endTime - startTime).toBeLessThan(100);
             });
         });
     });

--- a/tests/integration/dal/migrations/migrations.service.test.ts
+++ b/tests/integration/dal/migrations/migrations.service.test.ts
@@ -1,0 +1,78 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { prisma } from '@/lib/prisma';
+import { checkDbMigrations } from '@/dal/migrations/migrations.service';
+import { ReadinessError } from '@/lib/errors/ReadinessError';
+
+const createMigrationsTable = async (): Promise<void> => {
+    await prisma.$executeRaw`
+        CREATE TABLE _prisma_migrations (
+            id VARCHAR(36) PRIMARY KEY,
+            checksum VARCHAR(64) NOT NULL,
+            finished_at TIMESTAMPTZ,
+            migration_name VARCHAR(255) NOT NULL,
+            logs TEXT,
+            rolled_back_at TIMESTAMPTZ,
+            started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            applied_steps_count INTEGER NOT NULL DEFAULT 0
+        )
+    `;
+};
+
+describe('Database migrations service integration tests', () => {
+    beforeAll(async () => {
+        await prisma.$connect();
+    });
+
+    afterAll(async () => {
+        await prisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations CASCADE`;
+        await prisma.$disconnect();
+    });
+
+    beforeEach(async () => {
+        await prisma.$executeRaw`DROP TABLE IF EXISTS _prisma_migrations CASCADE`;
+    });
+
+    describe('Check database migrations', () => {
+        it('Should return null when migrations table does not exist', async () => {
+            await expect(checkDbMigrations()).resolves.toBeNull();
+        });
+
+        it('Should throw ReadinessError when there are pending migrations', async () => {
+            await createMigrationsTable();
+            await prisma.$executeRaw`
+                INSERT INTO _prisma_migrations
+                    (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES
+                    ('pending-1', 'checksum-1', '001_pending', NULL, NULL, NOW(), 0)
+            `;
+
+            await expect(checkDbMigrations()).rejects.toBeInstanceOf(ReadinessError);
+        });
+
+        it('Should return null when there are no pending or applied migrations', async () => {
+            await createMigrationsTable();
+
+            await expect(checkDbMigrations()).resolves.toBeNull();
+        });
+
+        it('Should return the last applied migration when no pending migrations exist', async () => {
+            await createMigrationsTable();
+
+            await prisma.$executeRaw`
+                INSERT INTO _prisma_migrations
+                    (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES
+                    ('applied-1', 'checksum-1', '001_init', '2024-01-01T00:00:00Z', NULL, '2024-01-01T00:00:00Z', 1),
+                    ('applied-2', 'checksum-2', '002_add_table', '2024-02-01T00:00:00Z', NULL, '2024-02-01T00:00:00Z', 1)
+            `;
+
+            const result = await checkDbMigrations();
+
+            expect(result).not.toBeNull();
+            expect(result?.migrationName).toBe('002_add_table');
+            expect(result?.appliedStepsCount).toBe(1);
+            expect(result?.finishedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
+            expect(result?.startedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
+        });
+    });
+});

--- a/tests/integration/dal/migrations/migrations.service.test.ts
+++ b/tests/integration/dal/migrations/migrations.service.test.ts
@@ -94,6 +94,10 @@ describe('Database migrations service integration tests', () => {
             const result = await checkReady();
 
             expect(result.ok).toBe(true);
+            if (!result.ok) {
+                throw new Error('Expected ok response');
+            }
+
             expect(result.migrationDetails?.migrationName).toBe('002_add_table');
             expect(result.migrationDetails?.finishedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
         });

--- a/tests/integration/dal/migrations/migrations.service.test.ts
+++ b/tests/integration/dal/migrations/migrations.service.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { prisma } from '@/lib/prisma';
-import { checkDbMigrations } from '@/dal/migrations/migrations.service';
+import { checkDbMigrations, checkReady } from '@/dal/migrations/migrations.service';
 import { ReadinessError } from '@/lib/errors/ReadinessError';
 
 const createMigrationsTable = async (): Promise<void> => {
@@ -73,6 +73,48 @@ describe('Database migrations service integration tests', () => {
             expect(result?.appliedStepsCount).toBe(1);
             expect(result?.finishedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
             expect(result?.startedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
+        });
+    });
+
+    describe('Check database readiness', () => {
+        it('Should return ok true with null migration when migrations table does not exist', async () => {
+            await expect(checkReady()).resolves.toEqual({ ok: true, migration: null });
+        });
+
+        it('Should return ok true with last migration when applied migrations exist', async () => {
+            await createMigrationsTable();
+            await prisma.$executeRaw`
+                INSERT INTO _prisma_migrations
+                    (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES
+                    ('applied-1', 'checksum-1', '001_init', '2024-01-01T00:00:00Z', NULL, '2024-01-01T00:00:00Z', 1),
+                    ('applied-2', 'checksum-2', '002_add_table', '2024-02-01T00:00:00Z', NULL, '2024-02-01T00:00:00Z', 1)
+            `;
+
+            const result = await checkReady();
+
+            expect(result.ok).toBe(true);
+            expect(result.migration?.migrationName).toBe('002_add_table');
+            expect(result.migration?.finishedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
+        });
+
+        it('Should throw ReadinessError when pending migrations exist', async () => {
+            await createMigrationsTable();
+            await prisma.$executeRaw`
+                INSERT INTO _prisma_migrations
+                    (id, checksum, migration_name, finished_at, rolled_back_at, started_at, applied_steps_count)
+                VALUES
+                    ('pending-1', 'checksum-1', '001_pending', NULL, NULL, NOW(), 0)
+            `;
+
+            try {
+                await checkReady();
+                expect.fail('Expected checkReady to throw');
+            } catch (error) {
+                expect(error).toBeInstanceOf(ReadinessError);
+                expect((error as ReadinessError).reason).toBe('migrations');
+                expect((error as ReadinessError).message).toBe('Database has 1 unfinished migrations');
+            }
         });
     });
 });

--- a/tests/integration/dal/migrations/migrations.service.test.ts
+++ b/tests/integration/dal/migrations/migrations.service.test.ts
@@ -78,7 +78,7 @@ describe('Database migrations service integration tests', () => {
 
     describe('Check database readiness', () => {
         it('Should return ok true with null migration when migrations table does not exist', async () => {
-            await expect(checkReady()).resolves.toEqual({ ok: true, migration: null });
+            await expect(checkReady()).resolves.toEqual({ ok: true, migrationDetails: null });
         });
 
         it('Should return ok true with last migration when applied migrations exist', async () => {
@@ -94,8 +94,8 @@ describe('Database migrations service integration tests', () => {
             const result = await checkReady();
 
             expect(result.ok).toBe(true);
-            expect(result.migration?.migrationName).toBe('002_add_table');
-            expect(result.migration?.finishedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
+            expect(result.migrationDetails?.migrationName).toBe('002_add_table');
+            expect(result.migrationDetails?.finishedAt?.toISOString()).toBe('2024-02-01T00:00:00.000Z');
         });
 
         it('Should throw ReadinessError when pending migrations exist', async () => {

--- a/tests/unit/app/api/app/readyz/route.test.ts
+++ b/tests/unit/app/api/app/readyz/route.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GET } from '@/app/api/app/readyz/route';
+import { ReadinessError } from '@/lib/errors/ReadinessError';
+
+vi.mock('@/dal/migrations/migrations.service', () => ({
+    checkReady: vi.fn(),
+}));
+
+import { checkReady } from '@/dal/migrations/migrations.service';
+
+describe('GET /api/app/readyz (unit)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Should return 200 with readiness payload when checkReady succeeds', async () => {
+        vi.mocked(checkReady).mockResolvedValueOnce({
+            ok: true,
+            migration: {
+                migrationName: '002_add_table',
+                startedAt: new Date('2024-02-01T00:00:00Z'),
+                finishedAt: new Date('2024-02-01T00:00:00Z'),
+                appliedStepsCount: 1,
+            },
+        });
+
+        const res = await GET();
+
+        expect(res.status).toBe(200);
+        expect(res.headers.get('cache-control')).toBe('no-store, max-age=0');
+
+        const body = await res.json();
+        expect(body.ok).toBe(true);
+        expect(body.migration.migrationName).toBe('002_add_table');
+        expect(body.migration.appliedStepsCount).toBe(1);
+    });
+
+    it('Should return readiness error payload when ReadinessError is thrown (migrations)', async () => {
+        vi.mocked(checkReady).mockRejectedValueOnce(
+            new ReadinessError('migrations', 'Database has 1 unfinished migrations')
+        );
+
+        const res = await GET();
+
+        expect(res.status).toBe(503);
+        expect(res.headers.get('cache-control')).toBe('no-store, max-age=0');
+
+        const body = await res.json();
+        expect(body).toEqual({ ok: false, reason: 'migrations' });
+    });
+
+    it('Should return readiness error payload when ReadinessError is thrown (database)', async () => {
+        vi.mocked(checkReady).mockRejectedValueOnce(
+            new ReadinessError('database', 'Database not reachable')
+        );
+
+        const res = await GET();
+
+        expect(res.status).toBe(503);
+        expect(res.headers.get('cache-control')).toBe('no-store, max-age=0');
+
+        const body = await res.json();
+        expect(body).toEqual({ ok: false, reason: 'database' });
+    });
+
+    it('Should return 503 with db reason when an unknown error is thrown', async () => {
+        vi.mocked(checkReady).mockRejectedValueOnce(new Error('boom'));
+
+        const res = await GET();
+
+        expect(res.status).toBe(503);
+        expect(res.headers.get('cache-control')).toBe('no-store, max-age=0');
+
+        const body = await res.json();
+        expect(body).toEqual({ ok: false, reason: 'db' });
+    });
+});

--- a/tests/unit/app/api/app/readyz/route.test.ts
+++ b/tests/unit/app/api/app/readyz/route.test.ts
@@ -16,7 +16,7 @@ describe('GET /api/app/readyz (unit)', () => {
     it('Should return 200 with readiness payload when checkReady succeeds', async () => {
         vi.mocked(checkReady).mockResolvedValueOnce({
             ok: true,
-            migration: {
+            migrationDetails: {
                 migrationName: '002_add_table',
                 startedAt: new Date('2024-02-01T00:00:00Z'),
                 finishedAt: new Date('2024-02-01T00:00:00Z'),
@@ -31,8 +31,8 @@ describe('GET /api/app/readyz (unit)', () => {
 
         const body = await res.json();
         expect(body.ok).toBe(true);
-        expect(body.migration.migrationName).toBe('002_add_table');
-        expect(body.migration.appliedStepsCount).toBe(1);
+        expect(body.migrationDetails.migrationName).toBe('002_add_table');
+        expect(body.migrationDetails.appliedStepsCount).toBe(1);
     });
 
     it('Should return readiness error payload when ReadinessError is thrown (migrations)', async () => {

--- a/tests/unit/dal/migrations/migrations.service.test.ts
+++ b/tests/unit/dal/migrations/migrations.service.test.ts
@@ -6,6 +6,10 @@ vi.mock('@/dal/migrations/migrations.repo', () => ({
     getLastAppliedMigration: vi.fn(),
 }));
 
+vi.mock('@/dal/db/db.service', () => ({
+    checkDbReachable: vi.fn(),
+}));
+
 vi.mock('@/lib/logging/logger', () => ({
     logger: {
         with: () => ({
@@ -16,7 +20,8 @@ vi.mock('@/lib/logging/logger', () => ({
 }));
 
 import { countPendingMigrations, getLastAppliedMigration } from '@/dal/migrations/migrations.repo';
-import { checkDbMigrations } from '@/dal/migrations/migrations.service';
+import { checkDbMigrations, checkReady } from '@/dal/migrations/migrations.service';
+import { checkDbReachable } from '@/dal/db/db.service';
 
 const mockMigration = {
     migrationName: '002_add_table',
@@ -51,5 +56,56 @@ describe('Check database migrations unit tests', () => {
 
         await expect(checkDbMigrations()).resolves.toEqual(mockMigration);
         expect(getLastAppliedMigration).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('Check database readiness unit tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Should return ok true with migration when dependencies succeed', async () => {
+        vi.mocked(checkDbReachable).mockResolvedValue(undefined);
+        const migration = { ...mockMigration };
+        vi.mocked(countPendingMigrations).mockResolvedValue(0);
+        vi.mocked(getLastAppliedMigration).mockResolvedValue(migration);
+
+        await expect(checkReady()).resolves.toEqual({ ok: true, migration });
+        expect(checkDbReachable).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should propagate ReadinessError when checkDbReachable fails', async () => {
+        const err = new ReadinessError('database', 'Database not reachable');
+        vi.mocked(checkDbReachable).mockRejectedValueOnce(err);
+        const checkDbMigrationsSpy = vi.spyOn(
+            await import('@/dal/migrations/migrations.service'),
+            'checkDbMigrations'
+        );
+
+        try {
+            await checkReady();
+            expect.fail('Expected checkReady to throw');
+        } catch (error) {
+            expect(error).toBe(err);
+            expect(error).toBeInstanceOf(ReadinessError);
+            expect((error as ReadinessError).reason).toBe('database');
+            expect((error as ReadinessError).message).toBe('Database not reachable');
+        }
+        expect(checkDbMigrationsSpy).not.toHaveBeenCalled();
+    });
+
+    it('Should propagate ReadinessError when checkDbMigrations fails', async () => {
+        vi.mocked(checkDbReachable).mockResolvedValue(undefined);
+        vi.mocked(countPendingMigrations).mockResolvedValue(2);
+
+        try {
+            await checkReady();
+            expect.fail('Expected checkReady to throw');
+        } catch (error) {
+            expect(error).toBeInstanceOf(ReadinessError);
+            expect((error as ReadinessError).reason).toBe('migrations');
+            expect((error as ReadinessError).message).toBe('Database has 2 unfinished migrations');
+        }
+        expect(checkDbReachable).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/unit/dal/migrations/migrations.service.test.ts
+++ b/tests/unit/dal/migrations/migrations.service.test.ts
@@ -70,7 +70,7 @@ describe('Check database readiness unit tests', () => {
         vi.mocked(countPendingMigrations).mockResolvedValue(0);
         vi.mocked(getLastAppliedMigration).mockResolvedValue(migration);
 
-        await expect(checkReady()).resolves.toEqual({ ok: true, migration });
+        await expect(checkReady()).resolves.toEqual({ ok: true, migrationDetails: migration });
         expect(checkDbReachable).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/unit/dal/migrations/migrations.service.test.ts
+++ b/tests/unit/dal/migrations/migrations.service.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReadinessError } from '@/lib/errors/ReadinessError';
+
+vi.mock('@/dal/migrations/migrations.repo', () => ({
+    countPendingMigrations: vi.fn(),
+    getLastAppliedMigration: vi.fn(),
+}));
+
+vi.mock('@/lib/logging/logger', () => ({
+    logger: {
+        with: () => ({
+            debug: vi.fn(),
+            error: vi.fn(),
+        }),
+    },
+}));
+
+import { countPendingMigrations, getLastAppliedMigration } from '@/dal/migrations/migrations.repo';
+import { checkDbMigrations } from '@/dal/migrations/migrations.service';
+
+const mockMigration = {
+    migrationName: '002_add_table',
+    startedAt: new Date('2024-02-01T00:00:00Z'),
+    finishedAt: new Date('2024-02-01T00:00:00Z'),
+    appliedStepsCount: 1,
+};
+
+describe('Check database migrations unit tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Should throw ReadinessError when there are pending migrations', async () => {
+        vi.mocked(countPendingMigrations).mockResolvedValue(2);
+
+        await expect(checkDbMigrations()).rejects.toBeInstanceOf(ReadinessError);
+        expect(getLastAppliedMigration).not.toHaveBeenCalled();
+    });
+
+    it('Should return null when there are no pending migrations and no last migration', async () => {
+        vi.mocked(countPendingMigrations).mockResolvedValue(0);
+        vi.mocked(getLastAppliedMigration).mockResolvedValue(null);
+
+        await expect(checkDbMigrations()).resolves.toBeNull();
+        expect(getLastAppliedMigration).toHaveBeenCalledTimes(1);
+    });
+
+    it('Should return last migration when there are no pending migrations', async () => {
+        vi.mocked(countPendingMigrations).mockResolvedValue(0);
+        vi.mocked(getLastAppliedMigration).mockResolvedValue(mockMigration);
+
+        await expect(checkDbMigrations()).resolves.toEqual(mockMigration);
+        expect(getLastAppliedMigration).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/lib/timeouts.test.ts
+++ b/tests/unit/lib/timeouts.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { withTimeout } from '@/lib/timeouts';
+
+describe('WithTimeout function tests', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('Resolves when promise resolves before timeout', () => {
+        it('Should resolve with the value when original promise resolves before timeout', async () => {
+            const originalPromise = new Promise<string>((resolve) => {
+                setTimeout(() => resolve('success'), 100);
+            });
+
+            const timeoutPromise = withTimeout(originalPromise, 200);
+
+            const testPromise = timeoutPromise.then((result) => {
+                expect(result).toBe('success');
+                return result;
+            });
+
+            vi.advanceTimersByTime(100);
+            await expect(testPromise).resolves.toBe('success');
+        });
+
+        it('Should work with different data types', async () => {
+            const numberPromise = Promise.resolve(42);
+            const objectPromise = Promise.resolve({ data: 'test' });
+            const arrayPromise = Promise.resolve([1, 2, 3]);
+
+            await expect(withTimeout(numberPromise, 100)).resolves.toBe(42);
+            await expect(withTimeout(objectPromise, 100)).resolves.toEqual({ data: 'test' });
+            await expect(withTimeout(arrayPromise, 100)).resolves.toEqual([1, 2, 3]);
+        });
+    });
+
+    describe('Rejects when timeout occurs before promise resolves', () => {
+        it('Should reject with timeout error when promise takes too long', async () => {
+            const originalPromise = new Promise<string>((resolve) => {
+                setTimeout(() => resolve('success'), 200);
+            });
+
+            const timeoutPromise = withTimeout(originalPromise, 100);
+
+            const testPromise = timeoutPromise.catch((error) => {
+                expect(error.message).toBe('timeout');
+                throw error;
+            });
+
+            vi.advanceTimersByTime(100);
+            await expect(testPromise).rejects.toThrow('timeout');
+        });
+
+        it('Should reject immediately when timeout is 0', async () => {
+            const originalPromise = new Promise<string>(() => {});
+            const timeoutPromise = withTimeout(originalPromise, 0);
+
+            vi.advanceTimersByTime(0);
+            await expect(timeoutPromise).rejects.toThrow('timeout');
+        });
+    });
+
+    describe('Handles edge cases', () => {
+        it('Should not cancel the original promise when timeout occurs', async () => {
+            let originalResolved = false;
+            const originalPromise = new Promise<string>((resolve) => {
+                setTimeout(() => {
+                    originalResolved = true;
+                    resolve('late success');
+                }, 200);
+            });
+
+            const timeoutPromise = withTimeout(originalPromise, 100);
+
+            vi.advanceTimersByTime(100);
+            await expect(timeoutPromise).rejects.toThrow('timeout');
+
+            vi.advanceTimersByTime(100);
+            await vi.runAllTimersAsync();
+
+            expect(originalResolved).toBe(true);
+        });
+
+        it('Should propagate rejection from original promise', async () => {
+            const originalPromise = Promise.reject(new Error('original error'));
+
+            await expect(withTimeout(originalPromise, 100)).rejects.toThrow('original error');
+        });
+
+        it('Should handle synchronous promise resolution', async () => {
+            const immediatePromise = Promise.resolve('immediate');
+            await expect(withTimeout(immediatePromise, 100)).resolves.toBe('immediate');
+        });
+    });
+
+    describe('Race condition scenarios', () => {
+        it('Should handle promise that resolves exactly at timeout boundary', async () => {
+            const originalPromise = new Promise<string>((resolve) => {
+                setTimeout(() => resolve('boundary'), 100);
+            });
+
+            const timeoutPromise = withTimeout(originalPromise, 100);
+
+            // The race will depend on internal scheduling, but both outcomes are valid
+            // This test verifies it doesn't crash and returns a valid result
+            vi.advanceTimersByTime(100);
+
+            try {
+                const result = await timeoutPromise;
+                expect(['boundary', 'timeout']).toContain(result === 'boundary' ? 'boundary' : 'timeout');
+            } catch (error: unknown) {
+                if (error instanceof Error) {
+                    expect(error.message).toBe('timeout');
+                }
+            }
+        });
+    });
+});


### PR DESCRIPTION
## Closes #43 
- Add an util function for handling out timeouts. Provide tests for it
- Add repository method to check whether the migrations table exists within the persistency layer. Add integration tests
- Provide functions for retrieving out the amount of pending / applied migrations. Provide integration tests
- Provide function for obtaining the last applied migration. Provide integration tests 
- Add service util for checking out the database migrations. Provide tests
- Provide the API route. Add and fix tests