### PR TITLE
Provide Kubernetes manifests for pre-prod environment

### DIFF
--- a/deploy/k8s/preprod/app-deployment.yaml
+++ b/deploy/k8s/preprod/app-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/raresmusea/linklite:testing-sha
+          image: ghcr.io/raresmusea/linklite:testing-REPLACE-WITH-SHA
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/deploy/k8s/preprod/app-deployment.yaml
+++ b/deploy/k8s/preprod/app-deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linklite-app
+  namespace: linklite-preprod
+  labels:
+    app.kubernetes.io/name: linklite
+    app.kubernetes.io/component: app
+    app.kubernetes.io/environment: preprod
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: linklite
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: linklite
+        app.kubernetes.io/component: app
+        app.kubernetes.io/environment: preprod
+    spec:
+      containers:
+        - name: app
+          image: ghcr.io/raresmusea/linklite:testing-sha
+          imagePullPolicy: IfNotPresent
+
+          ports:
+            - name: http
+              containerPort: 3000
+
+          envFrom:
+            - configMapRef:
+                name: linklite-config
+            - secretRef:
+                name: linklite-secrets
+
+          readinessProbe:
+            httpGet:
+              path: /api/app/readyz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+          livenessProbe:
+            httpGet:
+              path: /api/app/healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10

--- a/deploy/k8s/preprod/app-service.yaml
+++ b/deploy/k8s/preprod/app-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: linklite-app
+  namespace: linklite-preprod
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: linklite
+    app.kubernetes.io/component: app
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/deploy/k8s/preprod/configmap.yaml
+++ b/deploy/k8s/preprod/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: linklite-config
+  namespace: linklite-preprod
+data:
+  APP_ENV: preprod
+  LOG_LEVEL: INFO
+  LOG_FORMAT: pretty
+  GHCR_USER: raresmusea

--- a/deploy/k8s/preprod/configmap.yaml
+++ b/deploy/k8s/preprod/configmap.yaml
@@ -7,4 +7,3 @@ data:
   APP_ENV: preprod
   LOG_LEVEL: INFO
   LOG_FORMAT: pretty
-  GHCR_USER: raresmusea

--- a/deploy/k8s/preprod/domain-enrichment-worker-deployment.yaml
+++ b/deploy/k8s/preprod/domain-enrichment-worker-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linklite-domain-enrichment-worker
+  namespace: linklite-preprod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: linklite
+      app.kubernetes.io/component: domain-enrichment-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: linklite
+        app.kubernetes.io/component: domain-enrichment-worker
+    spec:
+      containers:
+        - name: worker-domain
+          image: ghcr.io/raresmusea/linklite:testing-REPLACE-WITH-SHA
+          command: ["sh", "-lc", "pnpm start:domain-enrichment-worker"]
+          envFrom:
+            - configMapRef:
+                name: linklite-config
+            - secretRef:
+                name: linklite-secrets

--- a/deploy/k8s/preprod/ingress.yaml
+++ b/deploy/k8s/preprod/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: linklite
+  namespace: linklite-preprod
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: preprod.linklite.dev
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: linklite-app
+                port:
+                  number: 80

--- a/deploy/k8s/preprod/link-enrichment-worker-deployment.yaml
+++ b/deploy/k8s/preprod/link-enrichment-worker-deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linklite-link-enrichment-worker
+  namespace: linklite-preprod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: linklite
+      app.kubernetes.io/component: link-enrichment-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: linklite
+        app.kubernetes.io/component: link-enrichment-worker
+    spec:
+      containers:
+        - name: worker-domain
+          image: ghcr.io/raresmusea/linklite:testing-REPLACE-WITH-SHA
+          command: ["sh", "-lc", "pnpm start:link-enrichment-worker"]
+          envFrom:
+            - configMapRef:
+                name: linklite-config
+            - secretRef:
+                name: linklite-secrets

--- a/deploy/k8s/preprod/migrate-job.yaml
+++ b/deploy/k8s/preprod/migrate-job.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: linklite-migrate-REPLACE-WITH-SHA
+  namespace: linklite-prepod
+  labels:
+    app.kubernetes.io/name: linklite
+    app.kubernetes.io/component: migrate
+    app.kubernetes.io/environment: preprod
+spec:
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: linklite
+        app.kubernetes.io/component: migrate
+        app.kubernetes.io/environment: preprod
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: ghcr.io/raresmusea/linklite:testing-REPLACE-WITH-SHA
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: linklite-config
+            - secretRef:
+                name: linklite-secrets
+          command: [ "sh", "-lc", "pnpm prisma migrate deploy" ]

--- a/deploy/k8s/preprod/namespace.yaml
+++ b/deploy/k8s/preprod/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: linklite-preprod
+  labels:
+    app.kubernetes.io/name: linklite
+    app.kubernetes.io/part-of: linklite
+    app.kubernetes.io/environment: preprod
+    environment: preprod

--- a/deploy/k8s/preprod/secrets.yaml
+++ b/deploy/k8s/preprod/secrets.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: linklite-secrets
+  namespace: linklite-preprod
+type: Opaque
+stringData:
+  POSTGRES_USER: ""
+  POSTGRES_PASSWORD: ""
+  POSTGRES_DB: ""
+  POSTGRES_DB_PORT: ""
+  PRISMA_CLIENT_ENGINE_TYPE: ""


### PR DESCRIPTION
## Relates to #118 
### Closes #119 
- Add k8s namespace
- Provide secrets.yaml file 
- Add a basic configmap
- Provide app deployment
- Provide app service
- Provide app ingress
- Provide app job for migrating database
- Add deployment for the link enrichment worker