### PR TITLE
Define Kubernetes resource limits

### DIFF
--- a/.github/scripts/deploy/preprod-k8s/deploy.sh
+++ b/.github/scripts/deploy/preprod-k8s/deploy.sh
@@ -4,14 +4,22 @@ export KUBECONFIG=/home/ssm-user/.kube/config
 
 SSM_ENV="testing"
 NAMESPACE="linklite-preprod"
+APP_ENV="preprod"
 AWS_REGION="eu-north-1"
 
 : "${IMAGE_TAG:?IMAGE_TAG is required}"
 : "${HEAD_SHA:?HEAD_SHA is required}"
 
 GHCR_USER="raresmusea"
-IMAGE_BASE="ghcr.io/${GHCR_USER}/linklite"
-REMOTE_IMAGE="${IMAGE_BASE}:${IMAGE_TAG}"
+
+IMAGE_WEB_BASE="ghcr.io/${GHCR_USER}/linklite-app"
+IMAGE_WORKER_BASE="ghcr.io/${GHCR_USER}/linklite-worker"
+IMAGE_MIGRATE_BASE="ghcr.io/${GHCR_USER}/linklite-migrate"
+
+REMOTE_WEB="${IMAGE_WEB_BASE}:${IMAGE_TAG}"
+REMOTE_WORKER="${IMAGE_WORKER_BASE}:${IMAGE_TAG}"
+REMOTE_MIGRATE="${IMAGE_MIGRATE_BASE}:${IMAGE_TAG}"
+
 
 APP_DEPLOYMENT="linklite-app"
 WORKER_DOMAIN_DEPLOYMENT="linklite-domain-enrichment-worker"
@@ -30,13 +38,17 @@ getp() {
       --output text
 }
 
-echo "Deploying image: ${REMOTE_IMAGE}"
+echo "Deploying images:"
+echo "  WEB:    ${REMOTE_WEB}"
+echo "  WORKER: ${REMOTE_WORKER}"
+echo "  MIGRATE:${REMOTE_MIGRATE}"
 echo "Namespace: ${NAMESPACE}"
 
 POSTGRES_USER="$(getp POSTGRES_USER)"
 POSTGRES_PASSWORD="$(getp POSTGRES_PASSWORD)"
 POSTGRES_DB="$(getp POSTGRES_DB)"
 PRISMA_CLIENT_ENGINE_TYPE="$(getp PRISMA_CLIENT_ENGINE_TYPE)"
+APP_COMMIT_SHA="${IMAGE_TAG#testing-}"
 
 DB_HOST="db"
 DB_PORT="5432"
@@ -51,6 +63,9 @@ kubectl -n "${NAMESPACE}" create secret generic linklite-secrets \
   --from-literal=POSTGRES_DB="${POSTGRES_DB}" \
   --from-literal=PRISMA_CLIENT_ENGINE_TYPE="${PRISMA_CLIENT_ENGINE_TYPE}" \
   --from-literal=DATABASE_URL="${DATABASE_URL}" \
+  --from-literal=APP_ENV="${APP_ENV}" \
+  --from-literal=APP_COMMIT="${APP_COMMIT_SHA}" \
+  --from-literal=APP_VERSION="${IMAGE_TAG}" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 echo "Secrets synced."
@@ -101,14 +116,13 @@ spec:
       restartPolicy: Never
       containers:
         - name: migrate
-          image: ${REMOTE_IMAGE}
+          image: ${REMOTE_MIGRATE}
           imagePullPolicy: IfNotPresent
           envFrom:
             - configMapRef:
                 name: linklite-config
             - secretRef:
                 name: linklite-secrets
-          command: ["sh", "-lc", "pnpm prisma migrate deploy"]
 EOF
 
 echo "Waiting for migrations job..."
@@ -120,9 +134,9 @@ kubectl -n "${NAMESPACE}" wait --for=condition=complete job/"${JOB_NAME}" --time
 
 echo "Updating deployments..."
 
-kubectl -n "${NAMESPACE}" set image deployment/${APP_DEPLOYMENT} app="${REMOTE_IMAGE}"
-kubectl -n "${NAMESPACE}" set image deployment/${WORKER_DOMAIN_DEPLOYMENT} domain-enrichment-worker="${REMOTE_IMAGE}"
-kubectl -n "${NAMESPACE}" set image deployment/${WORKER_LINK_DEPLOYMENT} link-enrichment-worker="${REMOTE_IMAGE}"
+kubectl -n "${NAMESPACE}" set image deployment/${APP_DEPLOYMENT} app="${REMOTE_WEB}"
+kubectl -n "${NAMESPACE}" set image deployment/${WORKER_DOMAIN_DEPLOYMENT} domain-enrichment-worker="${REMOTE_WORKER}"
+kubectl -n "${NAMESPACE}" set image deployment/${WORKER_LINK_DEPLOYMENT} link-enrichment-worker="${REMOTE_WORKER}"
 
 echo "Waiting for rollout..."
 

--- a/.github/scripts/deploy/testing/deploy.sh
+++ b/.github/scripts/deploy/testing/deploy.sh
@@ -11,7 +11,7 @@ LOG_FORMAT=pretty
 
 : "${IMAGE_TAG:?IMAGE_TAG is required}"
 
-IMAGE_WEB_BASE="ghcr.io/${GHCR_USER}/linklite-web"
+IMAGE_WEB_BASE="ghcr.io/${GHCR_USER}/linklite-app"
 IMAGE_WORKER_BASE="ghcr.io/${GHCR_USER}/linklite-worker"
 IMAGE_MIGRATE_BASE="ghcr.io/${GHCR_USER}/linklite-migrate"
 

--- a/.github/scripts/deploy/testing/deploy.sh
+++ b/.github/scripts/deploy/testing/deploy.sh
@@ -10,12 +10,25 @@ LOG_LEVEL=INFO
 LOG_FORMAT=pretty
 
 : "${IMAGE_TAG:?IMAGE_TAG is required}"
-IMAGE_BASE="ghcr.io/${GHCR_USER}/linklite"
-REMOTE_IMAGE="${IMAGE_BASE}:${IMAGE_TAG}"
+
+IMAGE_WEB_BASE="ghcr.io/${GHCR_USER}/linklite-web"
+IMAGE_WORKER_BASE="ghcr.io/${GHCR_USER}/linklite-worker"
+IMAGE_MIGRATE_BASE="ghcr.io/${GHCR_USER}/linklite-migrate"
+
+REMOTE_WEB="${IMAGE_WEB_BASE}:${IMAGE_TAG}"
+REMOTE_WORKER="${IMAGE_WORKER_BASE}:${IMAGE_TAG}"
+REMOTE_MIGRATE="${IMAGE_MIGRATE_BASE}:${IMAGE_TAG}"
 
 APP_COMMIT_SHA="${IMAGE_TAG#testing-}"
-LOCAL_CURRENT="${IMAGE_BASE}:testing-current"
-LOCAL_PREVIOUS="${IMAGE_BASE}:testing-previous"
+
+LOCAL_WEB_CURRENT="${IMAGE_WEB_BASE}:testing-current"
+LOCAL_WEB_PREVIOUS="${IMAGE_WEB_BASE}:testing-previous"
+
+LOCAL_WORKER_CURRENT="${IMAGE_WORKER_BASE}:testing-current"
+LOCAL_WORKER_PREVIOUS="${IMAGE_WORKER_BASE}:testing-previous"
+
+LOCAL_MIGRATE_CURRENT="${IMAGE_MIGRATE_BASE}:testing-current"
+LOCAL_MIGRATE_PREVIOUS="${IMAGE_MIGRATE_BASE}:testing-previous"
 
 cd "$APP_DIR"
 
@@ -69,29 +82,45 @@ services:
       timeout: 5s
       retries: 20
 
+  migrate:
+    image: ${LOCAL_MIGRATE_CURRENT}
+    restart: "no"
+    env_file:
+      - .env
+    depends_on:
+      db:
+        condition: service_healthy
+
   app:
-    image: ${LOCAL_CURRENT}
+    image: ${LOCAL_WEB_CURRENT}
     restart: unless-stopped
     env_file:
       - .env
     ports:
       - "127.0.0.1:3000:3000"
     depends_on:
-      db:
-        condition: service_healthy
-    command: >
-      sh -lc "pnpm prisma migrate deploy && pnpm start"
+      migrate:
+        condition: service_completed_successfully
 
-  worker:
-    image: ${LOCAL_CURRENT}
+  domain-enrichment-worker:
+    image: ${LOCAL_WORKER_CURRENT}
     restart: unless-stopped
     env_file:
       - .env
     depends_on:
-      db:
-        condition: service_healthy
-    command: >
-      sh -lc "pnpm start:worker"
+      migrate:
+        condition: service_completed_successfully
+    command: ["node", "dist/worker/domain_enrichment/domain_enrichment_worker.js"]
+
+  link-enrichment-worker:
+    image: ${LOCAL_WORKER_CURRENT}
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+    command: ["node", "dist/worker/link_enrichment/link_enrichment_worker.js"]
 
 volumes:
   pgdata:
@@ -101,35 +130,59 @@ OLD_COMMIT=""
 if curl -fsS --max-time 3 "$URL" >/tmp/healthz_old.json 2>/dev/null; then
   OLD_COMMIT=$(grep -oE '"commit"\s*:\s*"[^"]+"' /tmp/healthz_old.json | head -n1 | sed -E 's/.*"commit"\s*:\s*"([^"]+)".*/\1/')
 fi
-
 echo "Old commit: ${OLD_COMMIT:-<none>}"
 
 echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
 
-echo "Deploying remote image: $REMOTE_IMAGE"
+# --- images (new) ---
+REMOTE_WEB="${IMAGE_WEB_BASE}:${IMAGE_TAG}"
+REMOTE_WORKER="${IMAGE_WORKER_BASE}:${IMAGE_TAG}"
+REMOTE_MIGRATE="${IMAGE_MIGRATE_BASE}:${IMAGE_TAG}"
 
-docker pull "$REMOTE_IMAGE"
+echo "Pulling:"
+echo "  $REMOTE_WEB"
+echo "  $REMOTE_WORKER"
+echo "  $REMOTE_MIGRATE"
 
-# Mark actual local version as previous (prepare deployment)
-if sudo docker image inspect "$LOCAL_CURRENT" >/dev/null 2>&1; then
-  CURR_ID=$(sudo docker image inspect "$LOCAL_CURRENT" --format '{{.Id}}')
-  sudo docker tag "$CURR_ID" "$LOCAL_PREVIOUS" || true
-  echo "Tagged previous version: $LOCAL_PREVIOUS"
-fi
+docker pull "$REMOTE_WEB"
+docker pull "$REMOTE_WORKER"
+docker pull "$REMOTE_MIGRATE"
 
-# The SHA becomes current image tag (actual deploy)
-sudo docker tag "$REMOTE_IMAGE" "$LOCAL_CURRENT"
-echo "Tagged current version: $LOCAL_CURRENT"
+tag_roll () {
+  local local_current="$1"
+  local local_previous="$2"
+  local remote_ref="$3"
 
+  if sudo docker image inspect "$local_current" >/dev/null 2>&1; then
+    CURR_ID=$(sudo docker image inspect "$local_current" --format '{{.Id}}')
+    sudo docker tag "$CURR_ID" "$local_previous" || true
+    echo "Tagged previous version: $local_previous"
+  fi
+
+  sudo docker tag "$remote_ref" "$local_current"
+  echo "Tagged current version: $local_current"
+}
+
+tag_roll "$LOCAL_WEB_CURRENT" "$LOCAL_WEB_PREVIOUS" "$REMOTE_WEB"
+tag_roll "$LOCAL_WORKER_CURRENT" "$LOCAL_WORKER_PREVIOUS" "$REMOTE_WORKER"
+tag_roll "$LOCAL_MIGRATE_CURRENT" "$LOCAL_MIGRATE_PREVIOUS" "$REMOTE_MIGRATE"
+
+# --- bring up db ---
 sudo docker-compose -f docker-compose.testing.yml up -d db
 
-sudo docker-compose -f docker-compose.testing.yml run --rm app pnpm prisma migrate deploy
+# --- run migrations (new) ---
+sudo docker-compose -f docker-compose.testing.yml run --rm migrate
 
-sudo docker-compose -f docker-compose.testing.yml up -d --no-deps --force-recreate app worker
+# --- recreate app + workers (new) ---
+sudo docker-compose -f docker-compose.testing.yml up -d --no-deps --force-recreate \
+  app domain-enrichment-worker link-enrichment-worker
 
 echo "Waiting for app to respond: $URL"
 SMOKE_OK="0"
+
 for i in {1..30}; do
+  NEW_COMMIT=""
+
   if curl -fsS --max-time 3 "$URL" >/tmp/healthz_new.json 2>/dev/null; then
     NEW_COMMIT=$(grep -oE '"commit"\s*:\s*"[^"]+"' /tmp/healthz_new.json | head -n1 | sed -E 's/.*"commit"\s*:\s*"([^"]+)".*/\1/')
 
@@ -139,13 +192,15 @@ for i in {1..30}; do
       break
     fi
 
-   if [ -n "${NEW_COMMIT:-}" ] && [ "$NEW_COMMIT" != "$OLD_COMMIT" ]; then
-     echo "Smoke check OK (commit changed: $OLD_COMMIT -> $NEW_COMMIT)"
-     SMOKE_OK="1"
-     break
-   fi
-  echo "Health reachable but commit SHA not changed yet (old=$OLD_COMMIT new=${NEW_COMMIT:-<missing>})"
+    if [ -n "$NEW_COMMIT" ] && [ "$NEW_COMMIT" != "$OLD_COMMIT" ]; then
+      echo "Smoke check OK (commit changed: $OLD_COMMIT -> $NEW_COMMIT)"
+      SMOKE_OK="1"
+      break
+    fi
+
+    echo "Health reachable but commit SHA not changed yet (old=$OLD_COMMIT new=${NEW_COMMIT:-<missing>})"
   fi
+
   sleep 2
 done
 
@@ -157,28 +212,38 @@ if [ "$SMOKE_OK" != "1" ]; then
   exit 1
 fi
 
-echo "Cleaning up workspace: Keep current/previous images; Removing older 'testing-*' tags"
-KEEP_IDS=$(sudo docker images "$IMAGE_BASE" --format '{{.Tag}} {{.ID}}' \
-  | awk '$1=="testing-current" || $1=="testing-previous" {print $2}' \
-  | sort -u)
+cleanup_repo () {
+  local image_base="$1"
+  local image_tag_keep="$2" # ex: testing-<sha>
 
-sudo docker images "$IMAGE_BASE" --format '{{.Tag}}' \
-  | grep '^testing-' \
-  | while read -r TAG; do
-    [ "$TAG" = "testing-current" ] && continue
-    [ "$TAG" = "testing-previous" ] && continue
-    [ "$TAG" = "$IMAGE_TAG" ] && continue
+  echo "Cleaning images for: $image_base (keep current/previous + $image_tag_keep)"
 
-    REF="${IMAGE_BASE}:${TAG}"
-    ID=$(sudo docker image inspect "$REF" --format '{{.Id}}' 2>/dev/null || true)
+  KEEP_IDS=$(sudo docker images "$image_base" --format '{{.Tag}} {{.ID}}' \
+    | awk '$1=="testing-current" || $1=="testing-previous" {print $2}' \
+    | sort -u)
 
-    if [ -n "$ID" ] && echo "$KEEP_IDS" | grep -q "$ID"; then
-      continue
-    fi
+  sudo docker images "$image_base" --format '{{.Tag}}' \
+    | grep '^testing-' \
+    | while read -r TAG; do
+        [ "$TAG" = "testing-current" ] && continue
+        [ "$TAG" = "testing-previous" ] && continue
+        [ "$TAG" = "$image_tag_keep" ] && continue
 
-    echo "Removing $REF"
-    docker rmi -f "$REF" || true
-    done
+        REF="${image_base}:${TAG}"
+        ID=$(sudo docker image inspect "$REF" --format '{{.Id}}' 2>/dev/null || true)
+
+        if [ -n "$ID" ] && echo "$KEEP_IDS" | grep -q "$ID"; then
+          continue
+        fi
+
+        echo "Removing $REF"
+        sudo docker rmi -f "$REF" || true
+      done
+}
+
+cleanup_repo "$IMAGE_WEB_BASE" "$IMAGE_TAG"
+cleanup_repo "$IMAGE_WORKER_BASE" "$IMAGE_TAG"
+cleanup_repo "$IMAGE_MIGRATE_BASE" "$IMAGE_TAG"
 
 # Delete caches and system data for content older than 168h (~7 days)
 sudo docker builder prune -af --filter "until=168h" || true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,18 +37,39 @@ jobs:
           SHA="${{github.sha}}"
           BRANCH="${{github.ref_name}}"
           
-          TAG_SHA="${REPO}:${BRANCH}-${SHA}"
-          TAG_BRANCH="${REPO}:${BRANCH}"
-          
-          echo "tags=${TAG_SHA},${TAG_BRANCH}" >> "$GITHUB_OUTPUT"
-          echo "tag_sha=${TAG_SHA}" >> "$GITHUB_OUTPUT"
+          echo "app_tags=${REPO}-web:${BRANCH}-${SHA},${REPO}-web:${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "worker_tags=${REPO}-worker:${BRANCH}-${SHA},${REPO}-worker:${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "migrate_tags=${REPO}-migrate:${BRANCH}-${SHA},${REPO}-migrate:${BRANCH}" >> "$GITHUB_OUTPUT"
 
-      - name: Build & push (multi-arch)
+      - name: Build & push app (multi-arch)
         uses: docker/build-push-action@v6
         with:
           context: .
+          target: run
           push: true
           platforms: linux/arm64,linux/amd64
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ steps.tags.outputs.app_tags }}
           build-args: |
-            DATABASE_URL=${{secrets.DATABASE_URL}}
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+
+      - name: Build & push workers (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: worker-run
+          push: true
+          platforms: linux/arm64,linux/amd64
+          tags: ${{ steps.tags.outputs.worker_tags }}
+          build-args: |
+            DATABASE_URL=${{ secrets.DATABASE_URL }}
+
+      - name: Build & push migrate (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: migrate
+          push: true
+          platforms: linux/arm64,linux/amd64
+          tags: ${{ steps.tags.outputs.migrate_tags }}
+          build-args: |
+            DATABASE_URL=${{ secrets.DATABASE_URL }}

--- a/deploy/k8s/preprod/app-deployment.yaml
+++ b/deploy/k8s/preprod/app-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: app
-          image: ghcr.io/raresmusea/linklite:testing-current
+          image: ghcr.io/raresmusea/linklite-app:testing-current
           imagePullPolicy: IfNotPresent
 
           ports:

--- a/deploy/k8s/preprod/app-deployment.yaml
+++ b/deploy/k8s/preprod/app-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: app
     app.kubernetes.io/environment: preprod
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: linklite
@@ -24,7 +24,13 @@ spec:
         - name: app
           image: ghcr.io/raresmusea/linklite-app:testing-current
           imagePullPolicy: IfNotPresent
-
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "300Mi"
+            limits:
+              cpu: "800m"
+              memory: "768Mi"
           ports:
             - name: http
               containerPort: 3000

--- a/deploy/k8s/preprod/domain-enrichment-worker-deployment.yaml
+++ b/deploy/k8s/preprod/domain-enrichment-worker-deployment.yaml
@@ -19,6 +19,13 @@ spec:
         - name: domain-enrichment-worker
           image: ghcr.io/raresmusea/linklite-worker:testing-current
           command: ["node", "dist/worker/domain_enrichment/domain_enrichment_worker.js"]
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "192Mi"
+            limits:
+              cpu: "500m"
+              memory: "384Mi"
           envFrom:
             - configMapRef:
                 name: linklite-config

--- a/deploy/k8s/preprod/domain-enrichment-worker-deployment.yaml
+++ b/deploy/k8s/preprod/domain-enrichment-worker-deployment.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       containers:
         - name: domain-enrichment-worker
-          image: ghcr.io/raresmusea/linklite:testing-current
-          command: ["sh", "-lc", "pnpm start:domain-enrichment-worker"]
+          image: ghcr.io/raresmusea/linklite-worker:testing-current
+          command: ["node", "dist/worker/domain_enrichment/domain_enrichment_worker.js"]
           envFrom:
             - configMapRef:
                 name: linklite-config

--- a/deploy/k8s/preprod/link-enrichment-worker-deployment.yaml
+++ b/deploy/k8s/preprod/link-enrichment-worker-deployment.yaml
@@ -17,8 +17,8 @@ spec:
     spec:
       containers:
         - name: link-enrichment-worker
-          image: ghcr.io/raresmusea/linklite:testing-current
-          command: ["sh", "-lc", "pnpm start:link-enrichment-worker"]
+          image: ghcr.io/raresmusea/linklite-worker:testing-current
+          command: ["node", "dist/worker/link_enrichment/link_enrichment_worker.js"]
           envFrom:
             - configMapRef:
                 name: linklite-config

--- a/deploy/k8s/preprod/link-enrichment-worker-deployment.yaml
+++ b/deploy/k8s/preprod/link-enrichment-worker-deployment.yaml
@@ -19,6 +19,13 @@ spec:
         - name: link-enrichment-worker
           image: ghcr.io/raresmusea/linklite-worker:testing-current
           command: ["node", "dist/worker/link_enrichment/link_enrichment_worker.js"]
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "192Mi"
+            limits:
+              cpu: "500m"
+              memory: "384Mi"
           envFrom:
             - configMapRef:
                 name: linklite-config

--- a/deploy/k8s/preprod/postgres/stateful-set.yaml
+++ b/deploy/k8s/preprod/postgres/stateful-set.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         app: postgres
     spec:
+      terminationGracePeriodSeconds: 60
       containers:
         - name: postgres
           image: postgres:16


### PR DESCRIPTION
## Relates to #130 
### Resolves #133 

Changelog:
- Split GitHub container registry single image publishment workflow into 3 separate publishments
- Update staging deployment script
- Update preprod deployment script
- Update Kubernetes manifest with respect to the new GHCR publishing mechanism 
- Provide app deployment resources limits
- Provide resource limits for the enrichment workers
- Provide termination grace period seconds for the pg stateful set
- Add 1GB of swap memory on the preprod instance