### PR TITLE
Enforce limited number of creations for unauthenticated users

### DIFF
--- a/app/api/shorten/route.ts
+++ b/app/api/shorten/route.ts
@@ -2,9 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { generateSlug } from '@/lib/utils';
 import { z } from 'zod';
 import { LinkCreationSchema } from '@/validation/LinkCreationSchema';
-import { createLink } from '@/dal/links/links.repo';
 import { getOrigin } from '@/lib/origin';
 import { AppError } from '@/lib/errors/AppError';
+import { getOrCreateAnonActor } from '@/dal/anon_actors/anon_actors.service';
+import { createAnonLinkWithQuota } from '@/dal/links/links.service';
+
+const ANON_CREATE_LIMIT = 5;
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
     try {
@@ -13,22 +16,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         if (!parsed.success) {
             const tree = z.treeifyError(parsed.error);
+            const firstIssueMessage = parsed.error.issues[0]?.message ?? 'Validation error';
             return NextResponse.json(
-                { success: false, error: 'Validation error', details: tree, code: 'VALIDATION_ERROR' },
+                { success: false, error: firstIssueMessage, details: tree, code: 'VALIDATION_ERROR' },
                 { status: 400 }
             );
         }
 
+        const { quota, isNewCookie } = await getOrCreateAnonActor();
+
         const { url } = parsed.data;
         const ownerId = null;
 
-        let created = null as Awaited<ReturnType<typeof createLink>> | null;
+        let created = null as Awaited<ReturnType<typeof createAnonLinkWithQuota>> | null;
 
         for (let attempts = 0; !created && attempts < 5; attempts++) {
             const slug = generateSlug();
 
             try {
-                created = await createLink({ ownerId, slug, targetUrl: url });
+                created = await createAnonLinkWithQuota(
+                    { ownerId, slug, targetUrl: url },
+                    quota.anonId,
+                    ANON_CREATE_LIMIT
+                );
             } catch (err) {
                 if (isPrismaUniqueError(err)) continue;
                 throw err;

--- a/app/globals.css
+++ b/app/globals.css
@@ -224,3 +224,12 @@
 .redirect-fallback:active {
     color: var(--primary);
 }
+
+@media (max-width: 767px) {
+    .quota-toast,
+    .quota-toast:hover,
+    .quota-toast:focus-within {
+        transform: translateX(-50%) !important;
+        transition: none !important;
+    }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { Header } from '@/components/specific/landing/Header';
 import React from 'react';
 import { ThemeProvider } from 'next-themes';
 import { Footer } from '@/components/shared/footer/Footer';
+import { Toaster } from '@/components/ui/sonner';
 
 const geistSans = Geist({
     variable: '--font-geist-sans',
@@ -40,6 +41,7 @@ export default function RootLayout({
                     <Header />
                     {children}
                     <Footer />
+                    <Toaster position="bottom-center" expand={false} />
                 </ThemeProvider>
             </body>
         </html>

--- a/components/specific/link-shortener/LinkShortener.tsx
+++ b/components/specific/link-shortener/LinkShortener.tsx
@@ -1,18 +1,25 @@
 'use client';
 
 import React, { useState, useTransition } from 'react';
-import { Link2, Copy, Check, Loader2 } from 'lucide-react';
+import { Link2, Copy, Check, Loader2, Bell, X } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { isCreatedLinkResponse } from '@/dal/links/links.types';
 import { isApiRouteResponseOf } from '@/lib/utils';
+import { isPlainObject } from '@/lib/guards';
+
+type ShortenErrorState = {
+    message: string;
+    code?: string;
+};
 
 export default function LinkShortener() {
     const [url, setUrl] = useState<string>('');
     const [shortUrl, setShortUrl] = useState<string>('');
-    const [error, setError] = useState<string>('');
+    const [error, setError] = useState<ShortenErrorState | null>(null);
     const [copied, setCopied] = useState<boolean>(false);
 
     const [isPending, startTransition] = useTransition();
@@ -24,37 +31,127 @@ export default function LinkShortener() {
             body: JSON.stringify({ url: longUrl }),
         });
 
-        const json = await res.json();
-        console.log(json);
+        const json: unknown = await res.json();
 
-        if (!isApiRouteResponseOf(json, isCreatedLinkResponse)) throw new Error('Bad shape');
-
-        if (!res.ok || !json.success) {
-            throw new Error('Link shortened failed');
+        if (!res.ok || (isPlainObject(json) && json.success === false)) {
+            if (isPlainObject(json) && typeof json.error === 'string') {
+                const apiError = new Error(json.error) as Error & { code?: string };
+                if (typeof json.code === 'string') {
+                    apiError.code = json.code;
+                }
+                throw apiError;
+            }
+            throw new Error('Failed to shorten URL. Please try again.');
         }
 
-        setShortUrl(json.data.shortUrl as string);
+        if (!isApiRouteResponseOf(json, isCreatedLinkResponse)) {
+            throw new Error('Unexpected response from server.');
+        }
+
+        if (!json.success) {
+            throw new Error(json.error || 'Failed to shorten URL. Please try again.');
+        }
+
+        setShortUrl(json.data.shortUrl);
         setUrl('');
         setCopied(false);
     }
 
-    const handleShorten = (e: React.FormEvent) => {
+    const handleShorten = (e: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) => {
         e.preventDefault();
-        setError('');
+        setError(null);
         setShortUrl('');
         setCopied(false);
 
         const trimmed = url.trim();
 
         if (!trimmed) {
-            setError('Please enter a URL');
+            setError({ message: 'Please enter a URL' });
             return;
         }
 
         startTransition(() => {
-            shortenUrl(trimmed).catch((err) => {
+            shortenUrl(trimmed).catch((err: unknown) => {
                 console.error(err);
-                setError(err.message || 'Failed to shorten URL. Please try again.');
+                const known = err as { message?: unknown; code?: unknown };
+                const nextError = {
+                    message:
+                        typeof known.message === 'string' && known.message
+                            ? known.message
+                            : 'Failed to shorten URL. Please try again.',
+                    code: typeof known.code === 'string' ? known.code : undefined,
+                };
+
+                if (nextError.code === 'QUOTA_EXCEEDED') {
+                    toast.custom(
+                        (id) => (
+                            <div className="relative w-full rounded-xl border border-border bg-popover/90 p-5 text-popover-foreground shadow-2xl backdrop-blur-md">
+                                <button
+                                    type="button"
+                                    aria-label="Close alert"
+                                    className="absolute right-3 top-3 rounded-md p-1 text-muted-foreground transition hover:bg-accent hover:text-accent-foreground"
+                                    onClick={() => toast.dismiss(id)}
+                                >
+                                    <X className="h-4 w-4" />
+                                </button>
+
+                                <div className="flex items-start gap-3 pr-8">
+                                    <div className="mt-0.5 rounded-full bg-primary/10 p-2">
+                                        <Bell className="h-4 w-4 text-primary" />
+                                    </div>
+                                    <div className="flex-1">
+                                        <p className="text-sm font-semibold">Anonymous limit reached</p>
+                                        <p className="mt-1 text-sm text-muted-foreground">{nextError.message}</p>
+                                        <div className="mt-3 flex flex-wrap gap-2">
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                onClick={() => {
+                                                    toast.dismiss(id);
+                                                    window.location.assign('/signup');
+                                                }}
+                                            >
+                                                Sign up
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="sm"
+                                                variant="outline"
+                                                onClick={() => {
+                                                    toast.dismiss(id);
+                                                    window.location.assign('/signin');
+                                                }}
+                                            >
+                                                Sign in
+                                            </Button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        ),
+                        {
+                            id: 'quota-exceeded',
+                            duration: Infinity,
+                            className: 'quota-toast !border-0 !bg-transparent !shadow-none !p-0 !m-0',
+                            style: {
+                                position: 'fixed',
+                                left: '50%',
+                                right: 'auto',
+                                bottom: '20px',
+                                top: 'auto',
+                                transform: 'translateX(-50%)',
+                                width: 'min(92vw, 760px)',
+                                maxWidth: '760px',
+                                margin: 0,
+                                zIndex: 100,
+                            },
+                        }
+                    );
+                    setError(null);
+                    return;
+                }
+
+                setError(nextError);
             });
         });
     };
@@ -104,7 +201,9 @@ export default function LinkShortener() {
                     </Button>
                 </div>
 
-                {error && <p className="text-sm text-destructive mt-1">{error}</p>}
+                {error?.code !== 'QUOTA_EXCEEDED' && error ? (
+                    <p className="text-sm text-destructive mt-1">{error.message}</p>
+                ) : null}
             </form>
 
             {shortUrl && !error && (

--- a/dal/anon_actors/anon_actors.repo.ts
+++ b/dal/anon_actors/anon_actors.repo.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@/generated/prisma/client';
 
 export async function upsertAnonActor(anonId: string, ipHash: string | null) {
     return prisma.anonActor.upsert({
@@ -13,4 +14,17 @@ export async function upsertAnonActor(anonId: string, ipHash: string | null) {
             lastIpAddrHash: ipHash ?? undefined,
         },
     });
+}
+
+export async function incrementAnonActorQuotaCountTx(
+    anonId: string,
+    limit: number,
+    tx: Prisma.TransactionClient
+): Promise<boolean> {
+    const res = await tx.anonActor.updateMany({
+        where: { anonId, createdCount: { lt: limit } },
+        data: { createdCount: { increment: 1 } },
+    });
+
+    return res.count === 1;
 }

--- a/dal/links/links.repo.ts
+++ b/dal/links/links.repo.ts
@@ -7,6 +7,7 @@ import { upsertDomainEnrichmentJob } from '@/dal/domain_enrichment_jobs/domain_e
 import { DomainEnrichmentJobStatus } from '@/generated/prisma/enums';
 import { upsertLinkEnrichmentJob } from '@/dal/link_enrichment_jobs/link_enrichment_jobs.repo';
 import { RedirectProbeResult } from '@/lib/redirect_safety/redirect_safety_types';
+import { Prisma } from '@/generated/prisma/client';
 
 export async function createLink(input: CreateLinkInput): Promise<CreatedLink> {
     const hostname = normalizeHostnameFromUrl(input.targetUrl);
@@ -43,6 +44,23 @@ export async function createLink(input: CreateLinkInput): Promise<CreatedLink> {
     await upsertLinkEnrichmentJob(createdLink.id);
 
     return createdLink;
+}
+
+export async function createLinkTx(tx: Prisma.TransactionClient, input: CreateLinkInput): Promise<CreatedLink> {
+    const hostname = normalizeHostnameFromUrl(input.targetUrl);
+    if (!hostname) throw new InvalidHostnameError();
+
+    const domain = await upsertDomain({ hostname }, tx);
+
+    return tx.link.create({
+        data: {
+            slug: input.slug,
+            targetUrl: input.targetUrl,
+            ownerId: input.ownerId,
+            domainId: domain.id,
+        },
+        select: { id: true, domainId: true, slug: true, targetUrl: true, ownerId: true },
+    });
 }
 
 export async function increaseClickCount(slug: string): Promise<number> {

--- a/dal/links/links.service.ts
+++ b/dal/links/links.service.ts
@@ -16,7 +16,7 @@ export async function createAnonLinkWithQuota(
         const succeeded = await incrementAnonActorQuotaCountTx(anonId, limit, tx);
 
         if (!succeeded) {
-            throw new QuotaExceededError();
+            throw new QuotaExceededError(limit);
         }
 
         return createLinkTx(tx, input);

--- a/dal/links/links.service.ts
+++ b/dal/links/links.service.ts
@@ -1,0 +1,29 @@
+import { CreatedLink, CreateLinkInput } from '@/dal/links/links.types';
+import { prisma } from '@/lib/prisma';
+import { incrementAnonActorQuotaCountTx } from '@/dal/anon_actors/anon_actors.repo';
+import { QuotaExceededError } from '@/lib/errors/QuotaExceededError';
+import { upsertDomainEnrichmentJob } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
+import { upsertLinkEnrichmentJob } from '@/dal/link_enrichment_jobs/link_enrichment_jobs.repo';
+import { createLinkTx } from '@/dal/links/links.repo';
+import { DomainEnrichmentJobStatus } from '@/generated/prisma/enums';
+
+export async function createAnonLinkWithQuota(
+    input: CreateLinkInput,
+    anonId: string,
+    limit: number
+): Promise<CreatedLink> {
+    const createdLink = await prisma.$transaction(async (tx) => {
+        const succeeded = await incrementAnonActorQuotaCountTx(anonId, limit, tx);
+
+        if (!succeeded) {
+            throw new QuotaExceededError();
+        }
+
+        return createLinkTx(tx, input);
+    });
+
+    await upsertDomainEnrichmentJob({ domainId: createdLink.domainId!, status: DomainEnrichmentJobStatus.PENDING });
+    await upsertLinkEnrichmentJob(createdLink.id);
+
+    return createdLink;
+}

--- a/lib/errors/QuotaExceededError.ts
+++ b/lib/errors/QuotaExceededError.ts
@@ -1,0 +1,14 @@
+import { AppError } from '@/lib/errors/AppError';
+
+export class QuotaExceededError extends AppError {
+  constructor(limit?: number) {
+    super(
+      'QUOTA_EXCEEDED',
+      limit
+        ? `You've reached the anonymous limit (${limit}). Sign up for free to create more short links.`
+        : "You've reached the anonymous limit. Sign up for free to create more short links.",
+      429,
+      true
+    );
+  }
+}

--- a/lib/errors/QuotaExceededError.ts
+++ b/lib/errors/QuotaExceededError.ts
@@ -5,7 +5,7 @@ export class QuotaExceededError extends AppError {
     super(
       'QUOTA_EXCEEDED',
       limit
-        ? `You've reached the anonymous limit (${limit}). Sign up for free to create more short links.`
+        ? `You've reached the anonymous limit of ${limit} links. Sign up for free to create more short links.`
         : "You've reached the anonymous limit. Sign up for free to create more short links.",
       429,
       true

--- a/tests/integration/app/api/shorten/route.test.ts
+++ b/tests/integration/app/api/shorten/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/shorten/route';
+import { prisma } from '@/lib/prisma';
+import { resetDb } from '@/tests/helpers/db';
+
+const mocks = vi.hoisted(() => {
+    const state = {
+        currentAnonCookie: undefined as string | undefined,
+        currentHeaders: new Headers(),
+    };
+    const mockCookieSet = vi.fn();
+    const mockCookies = vi.fn(async () => ({
+        get: (name: string) =>
+            name === 'anon_id' && state.currentAnonCookie ? { value: state.currentAnonCookie } : undefined,
+        set: mockCookieSet,
+    }));
+    const mockHeaders = vi.fn(async () => state.currentHeaders);
+
+    return {
+        state,
+        mockCookieSet,
+        mockCookies,
+        mockHeaders,
+    };
+});
+
+vi.mock('next/headers', () => ({
+    cookies: mocks.mockCookies,
+    headers: mocks.mockHeaders,
+}));
+
+function req(body: unknown): NextRequest {
+    return new NextRequest('http://localhost:3000/api/shorten', {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+            host: 'localhost:3000',
+            'x-forwarded-proto': 'http',
+            'x-forwarded-for': '1.2.3.4',
+        },
+        body: JSON.stringify(body),
+    });
+}
+
+describe('POST /api/shorten integration tests', () => {
+    beforeEach(async () => {
+        await resetDb();
+        vi.clearAllMocks();
+        vi.unstubAllEnvs();
+
+        mocks.state.currentAnonCookie = undefined;
+        mocks.state.currentHeaders = new Headers({ 'x-forwarded-for': '1.2.3.4' });
+
+        vi.stubEnv('IP_HASH_SALT', 'integration-test-salt');
+    });
+
+    it('Returns 400 with a human-readable message for invalid URL format', async () => {
+        const res = await POST(req({ url: 'not-a-valid-url' }));
+
+        expect(res.status).toBe(400);
+
+        const json = await res.json();
+        expect(json.success).toBe(false);
+        expect(json.code).toBe('VALIDATION_ERROR');
+        expect(json.error).toBe('Invalid URL format!');
+        expect(json.error.startsWith('[')).toBe(false);
+        expect(json.details).toBeDefined();
+    });
+
+    it('Returns 400 with code VALIDATION_ERROR when required url is missing', async () => {
+        const res = await POST(req({}));
+
+        expect(res.status).toBe(400);
+
+        const json = await res.json();
+        expect(json.success).toBe(false);
+        expect(json.code).toBe('VALIDATION_ERROR');
+        expect(typeof json.error).toBe('string');
+        expect(json.error.length).toBeGreaterThan(0);
+        expect(json.error.startsWith('[')).toBe(false);
+    });
+
+    it('Creates a link for a valid URL and returns shortUrl', async () => {
+        mocks.state.currentAnonCookie = 'anon-integration-route';
+
+        await prisma.anonActor.create({
+            data: {
+                anonId: 'anon-integration-route',
+                createdCount: 0,
+            },
+        });
+
+        const res = await POST(req({ url: 'https://example.com/path' }));
+
+        expect(res.status).toBe(201);
+
+        const json = await res.json();
+        expect(json.success).toBe(true);
+        expect(json.data.shortUrl).toMatch(/^http:\/\/localhost:3000\//);
+        expect(json.data.created.targetUrl).toBe('https://example.com/path');
+
+        const createdSlug = json.data.created.slug as string;
+        const link = await prisma.link.findUnique({ where: { slug: createdSlug } });
+        expect(link).not.toBeNull();
+
+        const actor = await prisma.anonActor.findUnique({ where: { anonId: 'anon-integration-route' } });
+        expect(actor?.createdCount).toBe(1);
+    });
+
+    it('Returns 429 when anon quota is exceeded', async () => {
+        mocks.state.currentAnonCookie = 'anon-over-limit';
+
+        await prisma.anonActor.create({
+            data: {
+                anonId: 'anon-over-limit',
+                createdCount: 5,
+            },
+        });
+
+        const res = await POST(req({ url: 'https://example.com/too-many' }));
+
+        expect(res.status).toBe(429);
+
+        const json = await res.json();
+        expect(json.success).toBe(false);
+        expect(json.code).toBe('QUOTA_EXCEEDED');
+        expect(typeof json.error).toBe('string');
+        expect(json.error).toContain('anonymous limit');
+
+        expect(await prisma.link.count()).toBe(0);
+
+        const actor = await prisma.anonActor.findUnique({ where: { anonId: 'anon-over-limit' } });
+        expect(actor?.createdCount).toBe(5);
+    });
+});

--- a/tests/integration/dal/anon_actors/anon_actors.repo.test.ts
+++ b/tests/integration/dal/anon_actors/anon_actors.repo.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { upsertAnonActor } from '@/dal/anon_actors/anon_actors.repo';
+import { incrementAnonActorQuotaCountTx, upsertAnonActor } from '@/dal/anon_actors/anon_actors.repo';
 import { prisma } from '@/lib/prisma';
 import { resetDb } from '@/tests/helpers/db';
 
@@ -62,6 +62,65 @@ describe('Anon Actors Repository Integration Tests', () => {
             });
 
             expect(actors).toHaveLength(1);
+        });
+    });
+
+    describe('Increment anonymous quota count (transactional)', () => {
+        it('Should increment createdCount and return true when under limit', async () => {
+            await upsertAnonActor('anon-quota-ok', 'hash-1');
+
+            const succeeded = await prisma.$transaction((tx) => incrementAnonActorQuotaCountTx('anon-quota-ok', 2, tx));
+
+            expect(succeeded).toBe(true);
+
+            const actor = await prisma.anonActor.findUnique({
+                where: { anonId: 'anon-quota-ok' },
+            });
+            expect(actor?.createdCount).toBe(1);
+        });
+
+        it('Should return false and not increment when actor is already at limit', async () => {
+            await prisma.anonActor.create({
+                data: {
+                    anonId: 'anon-quota-maxed',
+                    createdCount: 1,
+                },
+            });
+
+            const succeeded = await prisma.$transaction((tx) =>
+                incrementAnonActorQuotaCountTx('anon-quota-maxed', 1, tx),
+            );
+
+            expect(succeeded).toBe(false);
+
+            const actor = await prisma.anonActor.findUnique({
+                where: { anonId: 'anon-quota-maxed' },
+            });
+            expect(actor?.createdCount).toBe(1);
+        });
+
+        it('Should return false when actor does not exist', async () => {
+            const succeeded = await prisma.$transaction((tx) => incrementAnonActorQuotaCountTx('missing-actor', 3, tx));
+
+            expect(succeeded).toBe(false);
+            expect(await prisma.anonActor.count()).toBe(0);
+        });
+
+        it('Should roll back increment when outer transaction fails', async () => {
+            await upsertAnonActor('anon-tx-rollback', 'hash-1');
+
+            await expect(
+                prisma.$transaction(async (tx) => {
+                    const succeeded = await incrementAnonActorQuotaCountTx('anon-tx-rollback', 5, tx);
+                    expect(succeeded).toBe(true);
+                    throw new Error('force rollback');
+                }),
+            ).rejects.toThrow('force rollback');
+
+            const actor = await prisma.anonActor.findUnique({
+                where: { anonId: 'anon-tx-rollback' },
+            });
+            expect(actor?.createdCount).toBe(0);
         });
     });
 });

--- a/tests/integration/dal/links/links.repo.test.ts
+++ b/tests/integration/dal/links/links.repo.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, it, expect, vi, Mock } from 'vitest';
 import { prisma } from '@/lib/prisma';
-import { applyRedirectProbeResult, createLink, findLinkForRedirect, increaseClickCount } from '@/dal/links/links.repo';
+import {
+    applyRedirectProbeResult,
+    createLink,
+    createLinkTx,
+    findLinkForRedirect,
+    increaseClickCount,
+} from '@/dal/links/links.repo';
 import { normalizeHostnameFromUrl } from '@/lib/utils';
 import { upsertDomainEnrichmentJob } from '@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo';
 import { upsertLinkEnrichmentJob } from '@/dal/link_enrichment_jobs/link_enrichment_jobs.repo';
@@ -603,7 +609,76 @@ describe('Link Repository - Integration Tests', () => {
             });
         });
 
-    describe('increaseClickCount', () => {
+        describe('createLinkTx', () => {
+            it('Should create a link and domain within an existing transaction', async () => {
+                (normalizeHostnameFromUrl as Mock).mockReturnValue('tx-example.com');
+
+                const result = await prisma.$transaction((tx) =>
+                    createLinkTx(tx, {
+                        slug: 'tx-create',
+                        targetUrl: 'https://tx-example.com/path',
+                        ownerId: null,
+                    })
+                );
+
+                expect(result.slug).toBe('tx-create');
+                expect(result.targetUrl).toBe('https://tx-example.com/path');
+                expect(result.domainId).toBeDefined();
+
+                const persisted = await prisma.link.findUnique({
+                    where: { slug: 'tx-create' },
+                    include: { domain: true },
+                });
+
+                expect(persisted).toBeDefined();
+                expect(persisted?.domain?.hostname).toBe('tx-example.com');
+                expect(upsertDomainEnrichmentJob).not.toHaveBeenCalled();
+                expect(upsertLinkEnrichmentJob).not.toHaveBeenCalled();
+            });
+
+            it('Should throw InvalidHostnameError when hostname normalization fails', async () => {
+                (normalizeHostnameFromUrl as Mock).mockReturnValue(null);
+
+                await expect(
+                    prisma.$transaction((tx) =>
+                        createLinkTx(tx, {
+                            slug: 'tx-invalid-host',
+                            targetUrl: 'invalid-url',
+                            ownerId: null,
+                        })
+                    )
+                ).rejects.toThrow(InvalidHostnameError);
+
+                const links = await prisma.link.count();
+                const domains = await prisma.domain.count();
+                expect(links).toBe(0);
+                expect(domains).toBe(0);
+            });
+
+            it('Should roll back created records when outer transaction fails', async () => {
+                (normalizeHostnameFromUrl as Mock).mockReturnValue('rollback-example.com');
+
+                await expect(
+                    prisma.$transaction(async (tx) => {
+                        await createLinkTx(tx, {
+                            slug: 'tx-rollback',
+                            targetUrl: 'https://rollback-example.com',
+                            ownerId: null,
+                        });
+                        throw new Error('force rollback');
+                    })
+                ).rejects.toThrow('force rollback');
+
+                const link = await prisma.link.findUnique({ where: { slug: 'tx-rollback' } });
+                const domain = await prisma.domain.findFirst({
+                    where: { hostname: 'rollback-example.com' },
+                });
+                expect(link).toBeNull();
+                expect(domain).toBeNull();
+            });
+        });
+
+        describe('increaseClickCount', () => {
             beforeEach(async () => {
                 vi.mocked(normalizeHostnameFromUrl).mockReturnValue('example.com');
             });

--- a/tests/integration/dal/links/links.service.test.ts
+++ b/tests/integration/dal/links/links.service.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { createAnonLinkWithQuota } from '@/dal/links/links.service';
+import { prisma } from '@/lib/prisma';
+import { resetDb } from '@/tests/helpers/db';
+import { QuotaExceededError } from '@/lib/errors/QuotaExceededError';
+import { DomainEnrichmentJobStatus, LinkEnrichmentJobStatus } from '@/generated/prisma/enums';
+
+describe('Link with anonymous quota creation integration tests', () => {
+    beforeEach(async () => {
+        await resetDb();
+    });
+
+    it('Creates link, increments anon quota, and creates enrichment jobs', async () => {
+        await prisma.anonActor.create({
+            data: {
+                anonId: 'anon-ok',
+                createdCount: 0,
+            },
+        });
+
+        const result = await createAnonLinkWithQuota(
+            {
+                slug: 'anon-created',
+                targetUrl: 'https://example.com/path',
+                ownerId: null,
+            },
+            'anon-ok',
+            2
+        );
+
+        expect(result.slug).toBe('anon-created');
+
+        const actor = await prisma.anonActor.findUnique({ where: { anonId: 'anon-ok' } });
+        expect(actor?.createdCount).toBe(1);
+
+        const link = await prisma.link.findUnique({ where: { id: result.id } });
+        expect(link).not.toBeNull();
+
+        const domainJob = await prisma.domainEnrichmentJob.findUnique({
+            where: { domainId: result.domainId! },
+        });
+        expect(domainJob).not.toBeNull();
+        expect(domainJob?.status).toBe(DomainEnrichmentJobStatus.PENDING);
+
+        const linkJob = await prisma.linkEnrichmentJob.findUnique({
+            where: { linkId: result.id },
+        });
+        expect(linkJob).not.toBeNull();
+        expect(linkJob?.status).toBe(LinkEnrichmentJobStatus.PENDING);
+    });
+
+    it('Throws QuotaExceededError and persists nothing when actor reached limit', async () => {
+        await prisma.anonActor.create({
+            data: {
+                anonId: 'anon-maxed',
+                createdCount: 1,
+            },
+        });
+
+        await expect(
+            createAnonLinkWithQuota(
+                {
+                    slug: 'blocked-slug',
+                    targetUrl: 'https://example.com/blocked',
+                    ownerId: null,
+                },
+                'anon-maxed',
+                1
+            )
+        ).rejects.toThrow(QuotaExceededError);
+
+        const actor = await prisma.anonActor.findUnique({ where: { anonId: 'anon-maxed' } });
+        expect(actor?.createdCount).toBe(1);
+        expect(await prisma.link.count()).toBe(0);
+        expect(await prisma.domain.count()).toBe(0);
+        expect(await prisma.domainEnrichmentJob.count()).toBe(0);
+        expect(await prisma.linkEnrichmentJob.count()).toBe(0);
+    });
+
+    it('Rolls back quota increment when link creation fails in transaction', async () => {
+        await prisma.anonActor.create({
+            data: {
+                anonId: 'anon-rollback',
+                createdCount: 0,
+            },
+        });
+
+        const existingDomain = await prisma.domain.create({
+            data: {
+                hostname: 'example.com',
+            },
+        });
+
+        await prisma.link.create({
+            data: {
+                slug: 'duplicate-slug',
+                targetUrl: 'https://example.com/already',
+                ownerId: null,
+                domainId: existingDomain.id,
+            },
+        });
+
+        const domainJobCountBefore = await prisma.domainEnrichmentJob.count();
+        const linkJobCountBefore = await prisma.linkEnrichmentJob.count();
+
+        await expect(
+            createAnonLinkWithQuota(
+                {
+                    slug: 'duplicate-slug',
+                    targetUrl: 'https://example.com/new',
+                    ownerId: null,
+                },
+                'anon-rollback',
+                2
+            )
+        ).rejects.toMatchObject({ code: 'P2002' });
+
+        const actor = await prisma.anonActor.findUnique({ where: { anonId: 'anon-rollback' } });
+        expect(actor?.createdCount).toBe(0);
+
+        const links = await prisma.link.findMany({ where: { slug: 'duplicate-slug' } });
+        expect(links).toHaveLength(1);
+
+        expect(await prisma.domainEnrichmentJob.count()).toBe(domainJobCountBefore);
+        expect(await prisma.linkEnrichmentJob.count()).toBe(linkJobCountBefore);
+    });
+});

--- a/tests/ui/components/specific/link-shortener/LinkShortener.ui.test.tsx
+++ b/tests/ui/components/specific/link-shortener/LinkShortener.ui.test.tsx
@@ -1,9 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+    toastCustom: vi.fn(),
+    toastDismiss: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        custom: mocks.toastCustom,
+        dismiss: mocks.toastDismiss,
+    },
+}));
+
 import LinkShortener from '@/components/specific/link-shortener/LinkShortener';
 
-describe('LinkShortener', () => {
-    it('shows shortened url on success', async () => {
+describe('LinkShortener component UI tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Shows shortened url on success', async () => {
         vi.stubGlobal(
             'fetch',
             vi.fn(async () => ({
@@ -26,12 +43,12 @@ describe('LinkShortener', () => {
         expect(await screen.findByDisplayValue('http://x/a')).toBeInTheDocument();
     });
 
-    it('shows error message on failure', async () => {
+    it('Shows error message on failure', async () => {
         vi.stubGlobal(
             'fetch',
             vi.fn(async () => ({
                 ok: false,
-                json: async () => ({ success: false, error: 'bad', status: 400 }),
+                json: async () => ({ success: false, error: 'bad', code: 'INTERNAL', status: 400 }),
             }))
         );
 
@@ -45,6 +62,44 @@ describe('LinkShortener', () => {
         const buttons = screen.getAllByRole('button', { name: /shorten/i });
         fireEvent.click(buttons[0]);
 
-        expect(await screen.findByText(/Link shortened failed/i)).toBeInTheDocument();
+        expect(await screen.findByText('bad')).toBeInTheDocument();
+    });
+
+    it('Uses sonner toast with sign in/up actions for QUOTA_EXCEEDED errors', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({
+                ok: false,
+                json: async () => ({
+                    success: false,
+                    error: "You've reached the anonymous limit.",
+                    code: 'QUOTA_EXCEEDED',
+                    status: 429,
+                }),
+            }))
+        );
+
+        render(<LinkShortener />);
+
+        fireEvent.change(screen.getByPlaceholderText(/enter your long url/i), {
+            target: { value: 'https://example.com' },
+        });
+
+        fireEvent.click(screen.getByRole('button', { name: /shorten/i }));
+
+        await waitFor(() => {
+            expect(mocks.toastCustom).toHaveBeenCalledTimes(1);
+        });
+
+        const [renderer, options] = mocks.toastCustom.mock.calls[0];
+        expect(typeof renderer).toBe('function');
+        expect(options).toMatchObject({
+            id: 'quota-exceeded',
+            duration: Infinity,
+        });
+
+        const renderedToast = renderer('quota-exceeded');
+        render(renderedToast);
+        expect(screen.getByLabelText(/close alert/i)).toBeInTheDocument();
     });
 });

--- a/tests/unit/app/api/shorten/route.test.ts
+++ b/tests/unit/app/api/shorten/route.test.ts
@@ -1,20 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-import { createLink } from '@/dal/links/links.repo';
-import { generateSlug } from '@/lib/utils';
-import { POST } from '@/app/api/shorten/route';
-import type { CreateLinkInput, CreatedLink } from '@/dal/links/links.types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
+import { POST } from '@/app/api/shorten/route';
+import { generateSlug } from '@/lib/utils';
+import { getOrCreateAnonActor } from '@/dal/anon_actors/anon_actors.service';
+import { createAnonLinkWithQuota } from '@/dal/links/links.service';
+import { QuotaExceededError } from '@/lib/errors/QuotaExceededError';
 
-type CreateLinkFn = (input: CreateLinkInput) => Promise<CreatedLink>;
-type GenerateSlugFn = (input: number) => string;
+vi.mock('@/lib/utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/lib/utils')>();
+    return {
+        ...actual,
+        generateSlug: vi.fn(),
+    };
+});
 
-vi.mock('@/dal/links/links.repo', () => ({
-    createLink: vi.fn<CreateLinkFn>(),
+vi.mock('@/dal/anon_actors/anon_actors.service', () => ({
+    getOrCreateAnonActor: vi.fn(),
 }));
 
-vi.mock('@/lib/utils', () => ({
-    generateSlug: vi.fn<GenerateSlugFn>(),
+vi.mock('@/dal/links/links.service', () => ({
+    createAnonLinkWithQuota: vi.fn(),
 }));
 
 function req(body: unknown): NextRequest {
@@ -22,7 +27,6 @@ function req(body: unknown): NextRequest {
         method: 'POST',
         headers: {
             'content-type': 'application/json',
-            // important pt getOriginFromHeaders():
             host: 'localhost:3000',
             'x-forwarded-proto': 'http',
         },
@@ -30,28 +34,50 @@ function req(body: unknown): NextRequest {
     });
 }
 
-// Keep this small: we only need the `code` field for P2002 detection
 type PrismaLikeError = Error & { code?: string };
 
-describe('POST /api/shorten', () => {
+describe('POST /api/shorten (unit tests)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        // Ensure stable shortUrl generation in tests unless you override it
-        process.env.NEXT_PUBLIC_APP_URL = 'http://localhost:3000';
+
+        vi.mocked(getOrCreateAnonActor).mockResolvedValue({
+            isNewCookie: false,
+            quota: {
+                anonId: 'anon-unit',
+                createdCount: 0,
+            },
+        });
     });
 
-    it('returns 400 on invalid body', async () => {
-        const res = await POST(req({}) as never); // cast only at the framework boundary
+    it('Returns 400 with first validation issue for invalid URL format', async () => {
+        const res = await POST(req({ url: 'not-a-valid-url' }) as never);
+
         expect(res.status).toBe(400);
 
         const json = await res.json();
-        expect(json.error).toBe('Validation error');
+        expect(json.success).toBe(false);
+        expect(json.code).toBe('VALIDATION_ERROR');
+        expect(json.error).toBe('Invalid URL format!');
+        expect(json.error.startsWith('[')).toBe(false);
     });
 
-    it('creates link and returns shortUrl', async () => {
+    it('Returns 400 with code VALIDATION_ERROR when body is invalid', async () => {
+        const res = await POST(req({}) as never);
+
+        expect(res.status).toBe(400);
+
+        const json = await res.json();
+        expect(json.success).toBe(false);
+        expect(json.code).toBe('VALIDATION_ERROR');
+        expect(typeof json.error).toBe('string');
+        expect(json.error.length).toBeGreaterThan(0);
+        expect(json.error.startsWith('[')).toBe(false);
+    });
+
+    it('Creates link and returns shortUrl', async () => {
         vi.mocked(generateSlug).mockReturnValueOnce('abc123');
 
-        vi.mocked(createLink).mockResolvedValueOnce({
+        vi.mocked(createAnonLinkWithQuota).mockResolvedValueOnce({
             id: '1',
             domainId: '2',
             slug: 'abc123',
@@ -60,37 +86,31 @@ describe('POST /api/shorten', () => {
         });
 
         const res = await POST(req({ url: 'https://example.com' }) as never);
+
         expect(res.status).toBe(201);
 
         const json = await res.json();
         expect(json.success).toBe(true);
-
-        // created link payload
-        expect(json.data.created).toEqual({
-            id: '1',
-            domainId: '2',
-            slug: 'abc123',
-            targetUrl: 'https://example.com',
-            ownerId: null,
-        });
-
-        // shortUrl
+        expect(json.data.created.slug).toBe('abc123');
         expect(json.data.shortUrl).toBe('http://localhost:3000/abc123');
 
-        // repo called with expected input
-        expect(vi.mocked(createLink)).toHaveBeenCalledWith({
-            ownerId: null,
-            slug: 'abc123',
-            targetUrl: 'https://example.com',
-        });
+        expect(vi.mocked(createAnonLinkWithQuota)).toHaveBeenCalledWith(
+            {
+                ownerId: null,
+                slug: 'abc123',
+                targetUrl: 'https://example.com',
+            },
+            'anon-unit',
+            5,
+        );
     });
 
-    it('retries on P2002 (slug collision) and succeeds on next attempt', async () => {
+    it('Retries on P2002 and succeeds on next attempt', async () => {
         vi.mocked(generateSlug).mockReturnValueOnce('dup').mockReturnValueOnce('ok');
 
         const p2002: PrismaLikeError = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
 
-        vi.mocked(createLink).mockRejectedValueOnce(p2002).mockResolvedValueOnce({
+        vi.mocked(createAnonLinkWithQuota).mockRejectedValueOnce(p2002).mockResolvedValueOnce({
             id: '2',
             domainId: '2',
             slug: 'ok',
@@ -99,17 +119,16 @@ describe('POST /api/shorten', () => {
         });
 
         const res = await POST(req({ url: 'https://example.com' }) as never);
-        expect(res.status).toBe(201);
 
-        // should have tried twice
-        expect(vi.mocked(createLink).mock.calls.length).toBe(2);
+        expect(res.status).toBe(201);
+        expect(vi.mocked(createAnonLinkWithQuota).mock.calls.length).toBe(2);
 
         const json = await res.json();
         expect(json.data.created.slug).toBe('ok');
         expect(json.data.shortUrl).toBe('http://localhost:3000/ok');
     });
 
-    it('returns 500 if slug collision happens 5 times', async () => {
+    it('Returns 500 if slug collision happens 5 times', async () => {
         vi.mocked(generateSlug)
             .mockReturnValueOnce('s1')
             .mockReturnValueOnce('s2')
@@ -119,25 +138,42 @@ describe('POST /api/shorten', () => {
 
         const p2002: PrismaLikeError = Object.assign(new Error('Unique constraint failed'), { code: 'P2002' });
 
-        vi.mocked(createLink).mockRejectedValue(p2002); // all attempts collide
+        vi.mocked(createAnonLinkWithQuota).mockRejectedValue(p2002);
 
         const res = await POST(req({ url: 'https://example.com' }) as never);
+
         expect(res.status).toBe(500);
 
         const json = await res.json();
+        expect(json.code).toBe('SLUG_EXHAUSTED');
         expect(json.error).toContain('Could not generate a unique slug');
-
-        expect(vi.mocked(createLink).mock.calls.length).toBe(5);
+        expect(vi.mocked(createAnonLinkWithQuota).mock.calls.length).toBe(5);
     });
 
-    it('returns 500 on non-P2002 errors', async () => {
+    it('Returns 429 when quota is exceeded', async () => {
         vi.mocked(generateSlug).mockReturnValueOnce('abc123');
-        vi.mocked(createLink).mockRejectedValueOnce(new Error('DB down'));
+        vi.mocked(createAnonLinkWithQuota).mockRejectedValueOnce(new QuotaExceededError(5));
 
         const res = await POST(req({ url: 'https://example.com' }) as never);
+
+        expect(res.status).toBe(429);
+
+        const json = await res.json();
+        expect(json.success).toBe(false);
+        expect(json.code).toBe('QUOTA_EXCEEDED');
+        expect(json.error).toContain('anonymous limit');
+    });
+
+    it('Returns 500 on non-P2002 unknown errors', async () => {
+        vi.mocked(generateSlug).mockReturnValueOnce('abc123');
+        vi.mocked(createAnonLinkWithQuota).mockRejectedValueOnce(new Error('DB down'));
+
+        const res = await POST(req({ url: 'https://example.com' }) as never);
+
         expect(res.status).toBe(500);
 
         const json = await res.json();
+        expect(json.code).toBe('INTERNAL');
         expect(json.error).toContain('Internal server error');
     });
 });

--- a/tests/unit/dal/links/links.service.test.ts
+++ b/tests/unit/dal/links/links.service.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DomainEnrichmentJobStatus } from '@/generated/prisma/enums';
+import { QuotaExceededError } from '@/lib/errors/QuotaExceededError';
+
+const mocks = vi.hoisted(() => ({
+    mockTransaction: vi.fn(),
+    mockIncrementAnonActorQuotaCountTx: vi.fn(),
+    mockCreateLinkTx: vi.fn(),
+    mockUpsertDomainEnrichmentJob: vi.fn(),
+    mockUpsertLinkEnrichmentJob: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+    prisma: {
+        $transaction: mocks.mockTransaction,
+    },
+}));
+
+vi.mock('@/dal/anon_actors/anon_actors.repo', () => ({
+    incrementAnonActorQuotaCountTx: mocks.mockIncrementAnonActorQuotaCountTx,
+}));
+
+vi.mock('@/dal/links/links.repo', () => ({
+    createLinkTx: mocks.mockCreateLinkTx,
+}));
+
+vi.mock('@/dal/domain_enrichment_jobs/domain_enrichment_jobs.repo', () => ({
+    upsertDomainEnrichmentJob: mocks.mockUpsertDomainEnrichmentJob,
+}));
+
+vi.mock('@/dal/link_enrichment_jobs/link_enrichment_jobs.repo', () => ({
+    upsertLinkEnrichmentJob: mocks.mockUpsertLinkEnrichmentJob,
+}));
+
+import { createAnonLinkWithQuota } from '@/dal/links/links.service';
+
+describe('Link with anonymous quota creation unit tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mocks.mockTransaction.mockImplementation(async (fn: (tx: object) => Promise<unknown>) => fn({}));
+    });
+
+    it('Creates link in transaction, increments quota, and enqueues enrichment jobs', async () => {
+        const created = {
+            id: 'link-1',
+            domainId: 'domain-1',
+            slug: 'unit-slug',
+            targetUrl: 'https://example.com',
+            ownerId: null,
+        };
+
+        mocks.mockIncrementAnonActorQuotaCountTx.mockResolvedValue(true);
+        mocks.mockCreateLinkTx.mockResolvedValue(created);
+
+        const result = await createAnonLinkWithQuota(
+            {
+                slug: 'unit-slug',
+                targetUrl: 'https://example.com',
+                ownerId: null,
+            },
+            'anon-1',
+            5
+        );
+
+        expect(result).toEqual(created);
+        expect(mocks.mockIncrementAnonActorQuotaCountTx).toHaveBeenCalledTimes(1);
+        expect(mocks.mockIncrementAnonActorQuotaCountTx).toHaveBeenCalledWith('anon-1', 5, expect.any(Object));
+        expect(mocks.mockCreateLinkTx).toHaveBeenCalledTimes(1);
+        expect(mocks.mockCreateLinkTx).toHaveBeenCalledWith(expect.any(Object), {
+            slug: 'unit-slug',
+            targetUrl: 'https://example.com',
+            ownerId: null,
+        });
+
+        expect(mocks.mockUpsertDomainEnrichmentJob).toHaveBeenCalledTimes(1);
+        expect(mocks.mockUpsertDomainEnrichmentJob).toHaveBeenCalledWith({
+            domainId: 'domain-1',
+            status: DomainEnrichmentJobStatus.PENDING,
+        });
+        expect(mocks.mockUpsertLinkEnrichmentJob).toHaveBeenCalledTimes(1);
+        expect(mocks.mockUpsertLinkEnrichmentJob).toHaveBeenCalledWith('link-1');
+    });
+
+    it('Throws QuotaExceededError and does not create link when quota increment fails', async () => {
+        mocks.mockIncrementAnonActorQuotaCountTx.mockResolvedValue(false);
+
+        await expect(
+            createAnonLinkWithQuota(
+                {
+                    slug: 'quota-fail',
+                    targetUrl: 'https://example.com',
+                    ownerId: null,
+                },
+                'anon-limit',
+                1
+            )
+        ).rejects.toThrow(QuotaExceededError);
+
+        expect(mocks.mockCreateLinkTx).not.toHaveBeenCalled();
+        expect(mocks.mockUpsertDomainEnrichmentJob).not.toHaveBeenCalled();
+        expect(mocks.mockUpsertLinkEnrichmentJob).not.toHaveBeenCalled();
+    });
+
+    it('Does not enqueue enrichment jobs if createLinkTx fails inside transaction', async () => {
+        mocks.mockIncrementAnonActorQuotaCountTx.mockResolvedValue(true);
+        mocks.mockCreateLinkTx.mockRejectedValue(Object.assign(new Error('duplicate'), { code: 'P2002' }));
+
+        await expect(
+            createAnonLinkWithQuota(
+                {
+                    slug: 'dup',
+                    targetUrl: 'https://example.com',
+                    ownerId: null,
+                },
+                'anon-2',
+                3
+            )
+        ).rejects.toMatchObject({ code: 'P2002' });
+
+        expect(mocks.mockUpsertDomainEnrichmentJob).not.toHaveBeenCalled();
+        expect(mocks.mockUpsertLinkEnrichmentJob).not.toHaveBeenCalled();
+    });
+});

--- a/validation/LinkCreationSchema.ts
+++ b/validation/LinkCreationSchema.ts
@@ -27,7 +27,7 @@ export const LinkCreationSchema = z
             if (url.hostname === 'localhost' || url.hostname.endsWith('.localhost')) {
                 ctx.addIssue({
                     code: 'custom',
-                    message: 'Localhost URLs are not allowed',
+                    message: 'Localhost URLs are not allowed!',
                 });
             }
         }),


### PR DESCRIPTION
## Relates to #116 
### Resolves #151 and #152 
Changelog: 
- Add custom quota exceeded error
- Add transactional link create util. Provide integration tests
- Add anon actors repo helper for the infrastructure. Provide integration tests
- Update globals CSS configuration
- Provide a root layout based sonner
- Update link shortener UI component to provide a visual feedback on case of exceeded anon quota. Update UI tests
- Update /shorten API route. Add tests