### PR TITLE
Provide standalone Redis manifests for the Kubernetes preprod deployment

### DIFF
--- a/deploy/k8s/preprod/redis/redis-configmap.yaml
+++ b/deploy/k8s/preprod/redis/redis-configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-configmap
+  namespace: linklite-preprod
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    port 6379
+    
+    # no persistence
+    save ""
+    appendonly no
+    
+    # memory cap + eviction prevention
+    maxmemory 128mb
+    maxmemory-policy allkeys-lru
+    
+    tcp-keepalive 60
+    timeout 0

--- a/deploy/k8s/preprod/redis/redis-deployment.yaml
+++ b/deploy/k8s/preprod/redis/redis-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: linklite-redis
+  namespace: linklite-preprod
+  labels:
+    app.kubernetes.io/name: linklite-redis
+    app.kubernetes.io/component: rate-limiter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: linklite-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: linklite-redis
+        app.kubernetes.io/component: rate-limiter
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 6379
+              name: redis
+          args: [ "redis-server", "/usr/local/etc/redis/redis.conf" ]
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "25m"
+            limits:
+              memory: "160Mi"
+              cpu: "250m"
+          volumeMounts:
+            - name: redis-config
+              mountPath: /usr/local/etc/redis
+          readinessProbe:
+            exec:
+              command: [ "sh", "-lc", "redis-cli ping | grep PONG" ]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: [ "sh", "-lc", "redis-cli ping | grep PONG" ]
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: redis-config
+          configMap:
+            name: redis-configmap

--- a/deploy/k8s/preprod/redis/redis-service.yaml
+++ b/deploy/k8s/preprod/redis/redis-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: linklite-redis
+  namespace: linklite-preprod
+spec:
+  selector:
+    app.kubernetes.io/name: linklite-redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+  type: ClusterIP


### PR DESCRIPTION
## Relates to #153 
### Fixes #161 
Changelog:
- Provide Kubernetes configmap for the Redis instance  
- Provide Kubernetes deployment for the Redis instance
- Provide Kubernetes service for the Redis instance