### PR TITLE
Provide functionality for resetting out the password (forgot password)

### DIFF
--- a/app/(auth)/forgot-password/actions.ts
+++ b/app/(auth)/forgot-password/actions.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { auth } from '@/lib/auth/auth';
+import { logger } from '@/lib/logging/logger';
+import { ForgotPasswordInput, ForgotPasswordSchema } from '@/validation/ForgotPasswordSchema';
+import { AuthActionResult, validateAuthActionInput } from '@/lib/server/action_utils';
+
+const forgotPasswordLogger = logger.component('auth.password-reset.request-server').child(undefined, [
+    'auth',
+    'password-reset',
+]);
+
+export type ForgotPasswordResult = AuthActionResult<ForgotPasswordInput>;
+
+export async function requestPasswordReset(input: ForgotPasswordInput): Promise<ForgotPasswordResult> {
+    const parsedInput = validateAuthActionInput(ForgotPasswordSchema, input);
+
+    if (!parsedInput.success) {
+        return parsedInput;
+    }
+
+    const normalizedEmail = parsedInput.data.email.trim().toLowerCase();
+    const redirectBase = (process.env.BETTER_AUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? 'http://localhost:3000').replace(
+        /\/$/,
+        '',
+    );
+
+    try {
+        const result = await auth.api.requestPasswordReset({
+            body: {
+                email: normalizedEmail,
+                redirectTo: `${redirectBase}/reset-password`,
+            },
+        });
+
+        forgotPasswordLogger.info(`Password reset requested for ${normalizedEmail}.`);
+
+        return {
+            success: true,
+            message: result.message,
+        };
+    } catch (error) {
+        forgotPasswordLogger.error(`Failed password reset request for ${normalizedEmail}.`, { cause: error });
+
+        return {
+            success: false,
+            formError: 'Unable to request a password reset right now. Please try again.',
+        };
+    }
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function LoginPage() {
-    redirect('/signup');
+    redirect('/signin');
 }

--- a/app/(auth)/register/actions.ts
+++ b/app/(auth)/register/actions.ts
@@ -1,35 +1,19 @@
 'use server';
 
-import { z } from 'zod';
 import { RegisterSchema, RegistrationInput } from '@/validation/RegisterSchema';
 import { auth } from '@/lib/auth/auth';
 import { logger } from '@/lib/logging/logger';
+import { AuthActionResult, validateAuthActionInput } from '@/lib/server/action_utils';
 
 const registrationLogger = logger.component('auth.register.register-server').child(undefined, ['auth', 'register']);
 
-export type RegistrationResult =
-    | {
-          success: true;
-          message: string;
-      }
-    | {
-          success: false;
-          fieldErrors?: Partial<Record<keyof RegistrationInput, string[]>>;
-          formError?: string;
-      };
+export type RegistrationResult = AuthActionResult<RegistrationInput>;
 
 export async function signUp(input: RegistrationInput): Promise<RegistrationResult> {
-    const parsedInput = RegisterSchema.safeParse(input);
+    const parsedInput = validateAuthActionInput(RegisterSchema, input);
 
     if (!parsedInput.success) {
-        const tree = z.treeifyError(parsedInput.error);
-
-        return {
-            success: false,
-            fieldErrors: Object.fromEntries(
-                Object.entries(tree.properties ?? {}).map(([key, value]) => [key, value?.errors ?? []])
-            ) as Partial<Record<keyof RegistrationInput, string[]>>,
-        };
+        return parsedInput;
     }
 
     const { name, email, password } = parsedInput.data;

--- a/app/(auth)/reset-password/actions.ts
+++ b/app/(auth)/reset-password/actions.ts
@@ -1,0 +1,45 @@
+'use server';
+
+import { auth } from '@/lib/auth/auth';
+import { logger } from '@/lib/logging/logger';
+import { ResetPasswordInput, ResetPasswordSchema } from '@/validation/ResetPasswordSchema';
+import { AuthActionResult, validateAuthActionInput } from '@/lib/server/action_utils';
+
+const resetPasswordLogger = logger
+    .component('auth.password-reset.complete-server')
+    .child(undefined, ['auth', 'password-reset']);
+
+export type ResetPasswordResult = AuthActionResult<ResetPasswordInput>;
+
+export async function completeResetPassword(input: ResetPasswordInput): Promise<ResetPasswordResult> {
+    const parsedInput = validateAuthActionInput(ResetPasswordSchema, input);
+
+    if (!parsedInput.success) {
+        return parsedInput;
+    }
+
+    const { token, newPassword } = parsedInput.data;
+
+    try {
+        await auth.api.resetPassword({
+            body: {
+                token,
+                newPassword,
+            },
+        });
+
+        resetPasswordLogger.info('Password reset was completed successfully.');
+
+        return {
+            success: true,
+            message: 'Password updated successfully. You can sign in now.',
+        };
+    } catch (error) {
+        resetPasswordLogger.error('Failed to complete password reset.', { cause: error });
+
+        return {
+            success: false,
+            formError: 'Unable to reset password. This link may be invalid or expired.',
+        };
+    }
+}

--- a/app/(auth)/signin/actions.ts
+++ b/app/(auth)/signin/actions.ts
@@ -3,26 +3,17 @@
 import { logger } from '@/lib/logging/logger';
 import { auth } from '@/lib/auth/auth';
 import { LoginInput, LoginSchema } from '@/validation/LoginSchema';
-import { getTreeifiedError } from '@/lib/zod/error_treeifier';
+import { AuthActionResult, validateAuthActionInput } from '@/lib/server/action_utils';
 
 const loginLogger = logger.component('auth.login.login-server').child(undefined, ['auth', 'login']);
 
-export type LoginResult =
-    | {
-          success: true;
-          message: string;
-      }
-    | {
-          success: false;
-          fieldErrors?: Partial<Record<keyof LoginInput, string[]>>;
-          formError?: string;
-      };
+export type LoginResult = AuthActionResult<LoginInput>;
 
 export async function signIn(input: LoginInput): Promise<LoginResult> {
-    const parsedInput = LoginSchema.safeParse(input);
+    const parsedInput = validateAuthActionInput(LoginSchema, input);
 
     if (!parsedInput.success) {
-        return getTreeifiedError(parsedInput);
+        return parsedInput;
     }
 
     const { email, password } = parsedInput.data;

--- a/app/globals.css
+++ b/app/globals.css
@@ -240,17 +240,35 @@
     }
 }
 
+/*.register-success-toast,*/
+/*.register-success-toast:hover,*/
+/*.register-success-toast:focus-within {*/
+/*    background: oklch(0.97 0.003 285) !important;*/
+/*    border-color: oklch(0.88 0.008 285 / 0.6) !important;*/
+/*    color: oklch(0.25 0.008 285) !important;*/
+/*    box-shadow: 0 10px 28px oklch(0.50 0.01 285 / 0.10) !important;*/
+/*}*/
+
+/*.register-success-toast,*/
+/*.register-success-toast:hover,*/
+/*.register-success-toast:focus-within {*/
+/*    background: oklch(0.98 0.012 90) !important;*/
+/*    border-color: oklch(0.85 0.04 80 / 0.45) !important;*/
+/*    color: oklch(0.28 0.015 70) !important;*/
+/*    box-shadow: 0 10px 28px oklch(0.50 0.03 75 / 0.10) !important;*/
+/*}*/
+
 .register-success-toast,
 .register-success-toast:hover,
 .register-success-toast:focus-within {
-    background: oklch(0.97 0.02 68) !important;
-    border-color: oklch(0.76 0.14 60 / 0.55) !important;
-    color: oklch(0.34 0.03 42) !important;
-    box-shadow: 0 10px 28px oklch(0.45 0.04 55 / 0.22) !important;
+    background: oklch(1 0 0 / 0.92) !important;
+    border-color: oklch(0.646 0.222 41.116 / 0.25) !important; /* border orange brand subtil */
+    color: oklch(0.141 0.005 285) !important;
+    box-shadow: 0 10px 28px oklch(0.646 0.222 41 / 0.08) !important;
 }
 
 .register-success-toast [data-icon] svg {
-    color: oklch(0.7 0.18 60) !important;
+    color: oklch(0.65 0.18 55) !important;
 }
 
 .dark .register-success-toast,

--- a/components/shared/auth/AuthBadge.tsx
+++ b/components/shared/auth/AuthBadge.tsx
@@ -25,7 +25,7 @@ export function AuthBadge({ motionProps }: AuthBadgeProps) {
             variants={badgeVariants}
         >
             <div className="inline-flex items-center gap-3 rounded-3xl border border-border/60 bg-card/95 px-3 py-2.5 pr-4 shadow-md backdrop-blur">
-                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-sm">
+                <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-linear-to-br from-primary to-primary/70 text-primary-foreground shadow-sm">
                     <Link2 className="h-5 w-5" />
                 </div>
                 <p className="text-[1.95rem] leading-none font-semibold tracking-tight text-foreground">

--- a/components/specific/auth/login/LoginForm.tsx
+++ b/components/specific/auth/login/LoginForm.tsx
@@ -64,6 +64,12 @@ export function LoginForm() {
                     </FormField>
                 </div>
 
+                <div className="flex justify-end">
+                    <Link href="/forgot-password" className="text-sm font-medium text-primary hover:underline">
+                        Forgot password?
+                    </Link>
+                </div>
+
                 <Button type="submit" size="lg" className="mt-2 w-full" disabled={isAnySubmitting}>
                     {isSubmitting ? (
                         <>

--- a/components/specific/auth/password-reset/ForgotPasswordForm.tsx
+++ b/components/specific/auth/password-reset/ForgotPasswordForm.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight, Loader2, Mail } from 'lucide-react';
+import { AuthCard } from '@/components/shared/auth/AuthCard';
+import { FormField } from '@/components/shared/auth/FormField';
+import { IconInput } from '@/components/shared/forms/IconInput';
+import { Button } from '@/components/ui/button';
+import { useForgotPasswordForm } from '@/components/specific/auth/password-reset/hooks/useForgotPasswordForm';
+
+export function ForgotPasswordForm() {
+    const { register, handleSubmit, errors, isSubmitting, onSubmit } = useForgotPasswordForm();
+
+    return (
+        <AuthCard
+            eyebrow="Password recovery"
+            title="Reset password"
+            description="Enter your email and we will send you a secure reset link."
+            footer={
+                <>
+                    Remembered your password?{' '}
+                    <Link href="/signin" className="font-medium text-primary hover:underline">
+                        Back to sign in
+                    </Link>
+                </>
+            }
+        >
+            <form className="space-y-4" onSubmit={handleSubmit(onSubmit)} noValidate>
+                <FormField label="Email" id="email" error={errors.email?.message}>
+                    <IconInput
+                        icon={Mail}
+                        id="email"
+                        placeholder="jane.doe@acme.com"
+                        type="email"
+                        aria-invalid={!!errors.email}
+                        aria-describedby={errors.email ? 'email-error' : undefined}
+                        {...register('email')}
+                    />
+                </FormField>
+
+                <Button type="submit" size="lg" className="mt-2 w-full" disabled={isSubmitting}>
+                    {isSubmitting ? (
+                        <>
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Sending reset link...
+                        </>
+                    ) : (
+                        <>
+                            Send reset link
+                            <ArrowRight className="h-4 w-4" />
+                        </>
+                    )}
+                </Button>
+            </form>
+        </AuthCard>
+    );
+}

--- a/components/specific/auth/password-reset/hooks/useForgotPasswordForm.ts
+++ b/components/specific/auth/password-reset/hooks/useForgotPasswordForm.ts
@@ -1,0 +1,75 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { requestPasswordReset } from '@/app/(auth)/forgot-password/actions';
+import { ForgotPasswordInput, ForgotPasswordSchema } from '@/validation/ForgotPasswordSchema';
+
+const FORGOT_PASSWORD_TOAST_OPTIONS = {
+    duration: 4000,
+    closeButton: true,
+    dismissible: true,
+    className:
+        '!w-[min(92vw,640px)] !max-w-[640px] !bg-popover/90 !text-popover-foreground !border-border/70 !backdrop-blur-md',
+};
+
+const FORGOT_PASSWORD_SUCCESS_TOAST_CLASS =
+    '!w-[min(92vw,640px)] !max-w-[640px] register-success-toast !border !backdrop-blur-md';
+
+export function useForgotPasswordForm() {
+    const {
+        register,
+        handleSubmit,
+        setError,
+        formState: { errors, isSubmitting },
+    } = useForm<ForgotPasswordInput>({
+        resolver: zodResolver(ForgotPasswordSchema),
+        defaultValues: {
+            email: '',
+        },
+    });
+
+    const onSubmit = async (data: ForgotPasswordInput) => {
+        const result = await requestPasswordReset(data);
+
+        if (!result.success) {
+            let hasFieldErrors = false;
+
+            if (result.fieldErrors) {
+                for (const [field, messages] of Object.entries(result.fieldErrors)) {
+                    if (!messages?.length) continue;
+                    hasFieldErrors = true;
+
+                    setError(field as keyof ForgotPasswordInput, {
+                        type: 'server',
+                        message: messages[0],
+                    });
+                }
+            }
+
+            if (result.formError) {
+                toast.error(result.formError, {
+                    ...FORGOT_PASSWORD_TOAST_OPTIONS,
+                });
+            } else if (!hasFieldErrors) {
+                toast.error('Unable to request password reset. Please try again.', {
+                    ...FORGOT_PASSWORD_TOAST_OPTIONS,
+                });
+            }
+
+            return;
+        }
+
+        toast.success(result.message, {
+            ...FORGOT_PASSWORD_TOAST_OPTIONS,
+            className: FORGOT_PASSWORD_SUCCESS_TOAST_CLASS,
+        });
+    };
+
+    return {
+        register,
+        handleSubmit,
+        errors,
+        isSubmitting,
+        onSubmit,
+    };
+}

--- a/components/specific/auth/password-reset/hooks/useResetPasswordForm.ts
+++ b/components/specific/auth/password-reset/hooks/useResetPasswordForm.ts
@@ -1,0 +1,81 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
+import { completeResetPassword } from '@/app/(auth)/reset-password/actions';
+import { ResetPasswordInput, ResetPasswordSchema } from '@/validation/ResetPasswordSchema';
+
+const RESET_PASSWORD_TOAST_OPTIONS = {
+    duration: 4000,
+    closeButton: true,
+    dismissible: true,
+    className:
+        '!w-[min(92vw,640px)] !max-w-[640px] !bg-popover/90 !text-popover-foreground !border-border/70 !backdrop-blur-md',
+};
+
+const RESET_PASSWORD_SUCCESS_TOAST_CLASS =
+    '!w-[min(92vw,640px)] !max-w-[640px] register-success-toast !border !backdrop-blur-md';
+
+export function useResetPasswordForm(token: string) {
+    const router = useRouter();
+    const {
+        register,
+        handleSubmit,
+        setError,
+        formState: { errors, isSubmitting },
+    } = useForm<ResetPasswordInput>({
+        resolver: zodResolver(ResetPasswordSchema),
+        defaultValues: {
+            token,
+            newPassword: '',
+            confirmPassword: '',
+        },
+    });
+
+    const onSubmit = async (data: ResetPasswordInput) => {
+        const result = await completeResetPassword(data);
+
+        if (!result.success) {
+            let hasFieldErrors = false;
+
+            if (result.fieldErrors) {
+                for (const [field, messages] of Object.entries(result.fieldErrors)) {
+                    if (!messages?.length) continue;
+                    hasFieldErrors = true;
+
+                    setError(field as keyof ResetPasswordInput, {
+                        type: 'server',
+                        message: messages[0],
+                    });
+                }
+            }
+
+            if (result.formError) {
+                toast.error(result.formError, {
+                    ...RESET_PASSWORD_TOAST_OPTIONS,
+                });
+            } else if (!hasFieldErrors) {
+                toast.error('Unable to reset password. Please try again.', {
+                    ...RESET_PASSWORD_TOAST_OPTIONS,
+                });
+            }
+
+            return;
+        }
+
+        toast.success(result.message, {
+            ...RESET_PASSWORD_TOAST_OPTIONS,
+            className: RESET_PASSWORD_SUCCESS_TOAST_CLASS,
+        });
+
+        router.replace('/signin');
+    };
+
+    return {
+        register,
+        handleSubmit,
+        errors,
+        isSubmitting,
+        onSubmit,
+    };
+}

--- a/lib/auth/auth.ts
+++ b/lib/auth/auth.ts
@@ -27,6 +27,22 @@ function toTokenVerificationRoute(url: string): string {
     }
 }
 
+function toResetPasswordRoute(url: string): string {
+    try {
+        const parsedUrl = new URL(url);
+        const tokenFromQuery = parsedUrl.searchParams.get('token');
+        const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
+        const tokenFromPath = pathSegments[pathSegments.length - 1];
+        const token = tokenFromQuery || tokenFromPath;
+
+        if (!token) return url;
+
+        return `${parsedUrl.origin}/reset-password/${encodeURIComponent(token)}`;
+    } catch {
+        return url;
+    }
+}
+
 export const auth = betterAuth({
     database: prismaAdapter(prisma, {
         provider: 'postgresql',
@@ -41,7 +57,7 @@ export const auth = betterAuth({
         sendResetPassword: async ({ user, url }) => {
             const template = resetPasswordTemplate({
                 name: user.name,
-                resetUrl: url,
+                resetUrl: toResetPasswordRoute(url),
             });
 
             await sendEmail({

--- a/lib/server/action_utils.ts
+++ b/lib/server/action_utils.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import { getTreeifiedError } from '@/lib/zod/error_treeifier';
+
+type FieldErrors<T extends Record<string, unknown>> = Partial<Record<Extract<keyof T, string>, string[]>>;
+
+export type AuthActionResult<TFields extends Record<string, unknown>> =
+    | {
+          success: true;
+          message: string;
+      }
+    | {
+          success: false;
+          fieldErrors?: FieldErrors<TFields>;
+          formError?: string;
+      };
+
+export function validateAuthActionInput<T extends Record<string, unknown>>(
+    schema: z.ZodType<T>,
+    input: T
+): { success: true; data: T } | ReturnType<typeof getTreeifiedError<T>> {
+    const parsedInput = schema.safeParse(input);
+
+    if (!parsedInput.success) {
+        return getTreeifiedError(parsedInput);
+    }
+
+    return {
+        success: true,
+        data: parsedInput.data,
+    };
+}

--- a/tests/ui/components/specific/auth/password-reset/ForgotPasswordForm.ui.test.tsx
+++ b/tests/ui/components/specific/auth/password-reset/ForgotPasswordForm.ui.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+    useForgotPasswordForm: vi.fn(),
+    register: vi.fn((name: string) => ({
+        name,
+        onChange: vi.fn(),
+        onBlur: vi.fn(),
+        ref: vi.fn(),
+    })),
+    handleSubmit: vi.fn((onValid: (...args: unknown[]) => unknown) => (event?: { preventDefault?: () => void }) => {
+        event?.preventDefault?.();
+        return onValid({});
+    }),
+    onSubmit: vi.fn(),
+}));
+
+vi.mock('next/link', () => ({
+    default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+        <a href={href} {...props}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/components/shared/auth/AuthCard', () => ({
+    AuthCard: ({
+        eyebrow,
+        title,
+        description,
+        footer,
+        children,
+    }: {
+        eyebrow: string;
+        title: string;
+        description: string;
+        footer?: React.ReactNode;
+        children: React.ReactNode;
+    }) => (
+        <section>
+            <p>{eyebrow}</p>
+            <h1>{title}</h1>
+            <p>{description}</p>
+            {children}
+            {footer}
+        </section>
+    ),
+}));
+
+vi.mock('@/components/shared/forms/IconInput', () => ({
+    IconInput: ({ id, ...props }: React.InputHTMLAttributes<HTMLInputElement>) => <input id={id} {...props} />,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+    Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button {...props}>{children}</button>
+    ),
+}));
+
+vi.mock('@/components/specific/auth/password-reset/hooks/useForgotPasswordForm', () => ({
+    useForgotPasswordForm: mocks.useForgotPasswordForm,
+}));
+
+import { ForgotPasswordForm } from '@/components/specific/auth/password-reset/ForgotPasswordForm';
+
+function makeHookState(
+    overrides: Partial<{
+        errors: {
+            email?: { message?: string };
+        };
+        isSubmitting: boolean;
+    }> = {}
+) {
+    return {
+        register: mocks.register,
+        handleSubmit: mocks.handleSubmit,
+        errors: {},
+        isSubmitting: false,
+        onSubmit: mocks.onSubmit,
+        ...overrides,
+    };
+}
+
+describe('ForgotPasswordForm Component', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.useForgotPasswordForm.mockReturnValue(makeHookState());
+    });
+
+    it('Renders auth copy, email field, and footer link', () => {
+        render(<ForgotPasswordForm />);
+
+        expect(screen.getByText('Password recovery', { selector: 'p' })).toBeInTheDocument();
+        expect(screen.getByRole('heading', { name: 'Reset password' })).toBeInTheDocument();
+        expect(screen.getByText('Enter your email and we will send you a secure reset link.')).toBeInTheDocument();
+        expect(screen.getByLabelText('Email')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /send reset link/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Back to sign in' })).toHaveAttribute('href', '/signin');
+    });
+
+    it('Shows loading state and disables submit while submitting', () => {
+        mocks.useForgotPasswordForm.mockReturnValue(
+            makeHookState({
+                isSubmitting: true,
+            })
+        );
+
+        render(<ForgotPasswordForm />);
+
+        expect(screen.getByRole('button', { name: /sending reset link/i })).toBeDisabled();
+    });
+
+    it('Wires form submit through handleSubmit', () => {
+        const { container } = render(<ForgotPasswordForm />);
+        const form = container.querySelector('form');
+
+        expect(form).toBeInTheDocument();
+        if (form) {
+            fireEvent.submit(form);
+        }
+
+        expect(mocks.handleSubmit).toHaveBeenCalledTimes(1);
+        expect(mocks.handleSubmit).toHaveBeenCalledWith(mocks.onSubmit);
+        expect(mocks.onSubmit).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/ui/components/specific/auth/password-reset/hooks/useForgotPasswordForm.ui.test.ts
+++ b/tests/ui/components/specific/auth/password-reset/hooks/useForgotPasswordForm.ui.test.ts
@@ -1,0 +1,125 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ForgotPasswordInput } from '@/validation/ForgotPasswordSchema';
+
+const mocks = vi.hoisted(() => ({
+    requestPasswordReset: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+}));
+
+vi.mock('@/app/(auth)/forgot-password/actions', () => ({
+    requestPasswordReset: mocks.requestPasswordReset,
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        success: mocks.toastSuccess,
+        error: mocks.toastError,
+    },
+}));
+
+import { useForgotPasswordForm } from '@/components/specific/auth/password-reset/hooks/useForgotPasswordForm';
+
+const validPayload: ForgotPasswordInput = {
+    email: 'jane@example.com',
+};
+
+describe('useForgotPasswordForm hook tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Exposes default form state', () => {
+        const { result } = renderHook(() => useForgotPasswordForm());
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.errors.email).toBeUndefined();
+    });
+
+    it('Shows success toast when forgot-password request succeeds', async () => {
+        mocks.requestPasswordReset.mockResolvedValueOnce({
+            success: true,
+            message: 'Password reset email sent.',
+        });
+
+        const { result } = renderHook(() => useForgotPasswordForm());
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(mocks.requestPasswordReset).toHaveBeenCalledWith(validPayload);
+        expect(mocks.toastSuccess).toHaveBeenCalledWith(
+            'Password reset email sent.',
+            expect.objectContaining({
+                duration: 4000,
+                closeButton: true,
+                dismissible: true,
+                className: expect.stringContaining('register-success-toast'),
+            })
+        );
+    });
+
+    it('Shows form error toast when backend returns formError', async () => {
+        mocks.requestPasswordReset.mockResolvedValueOnce({
+            success: false,
+            formError: 'Unable to request a password reset right now. Please try again.',
+        });
+
+        const { result } = renderHook(() => useForgotPasswordForm());
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(mocks.toastError).toHaveBeenCalledWith(
+            'Unable to request a password reset right now. Please try again.',
+            expect.objectContaining({
+                duration: 4000,
+                closeButton: true,
+                dismissible: true,
+            })
+        );
+    });
+
+    it('Maps field errors to react-hook-form state and skips fallback toast', async () => {
+        mocks.requestPasswordReset.mockResolvedValueOnce({
+            success: false,
+            fieldErrors: {
+                email: ['Invalid email address'],
+            },
+        });
+
+        const { result } = renderHook(() => useForgotPasswordForm());
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(result.current.errors.email?.message).toBe('Invalid email address');
+        expect(mocks.toastError).not.toHaveBeenCalled();
+    });
+
+    it('Shows fallback error toast when response has no formError and no field errors', async () => {
+        mocks.requestPasswordReset.mockResolvedValueOnce({
+            success: false,
+        });
+
+        const { result } = renderHook(() => useForgotPasswordForm());
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(mocks.toastError).toHaveBeenCalledWith(
+            'Unable to request password reset. Please try again.',
+            expect.objectContaining({
+                duration: 4000,
+                closeButton: true,
+                dismissible: true,
+            })
+        );
+    });
+});

--- a/tests/ui/components/specific/auth/password-reset/hooks/useResetPasswordForm.ui.test.ts
+++ b/tests/ui/components/specific/auth/password-reset/hooks/useResetPasswordForm.ui.test.ts
@@ -1,0 +1,142 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ResetPasswordInput } from '@/validation/ResetPasswordSchema';
+
+const mocks = vi.hoisted(() => ({
+    completeResetPassword: vi.fn(),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+    replace: vi.fn(),
+}));
+
+vi.mock('@/app/(auth)/reset-password/actions', () => ({
+    completeResetPassword: mocks.completeResetPassword,
+}));
+
+vi.mock('sonner', () => ({
+    toast: {
+        success: mocks.toastSuccess,
+        error: mocks.toastError,
+    },
+}));
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({
+        replace: mocks.replace,
+    }),
+}));
+
+import { useResetPasswordForm } from '@/components/specific/auth/password-reset/hooks/useResetPasswordForm';
+
+const token = 'reset-token-123';
+
+const validPayload: ResetPasswordInput = {
+    token,
+    newPassword: 'Strong_Ab',
+    confirmPassword: 'Strong_Ab',
+};
+
+describe('useResetPasswordForm hook tests', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Exposes default form state', () => {
+        const { result } = renderHook(() => useResetPasswordForm(token));
+
+        expect(result.current.isSubmitting).toBe(false);
+        expect(result.current.errors.token).toBeUndefined();
+        expect(result.current.errors.newPassword).toBeUndefined();
+        expect(result.current.errors.confirmPassword).toBeUndefined();
+    });
+
+    it('Shows success toast and redirects to signin when reset succeeds', async () => {
+        mocks.completeResetPassword.mockResolvedValueOnce({
+            success: true,
+            message: 'Password updated successfully. You can sign in now.',
+        });
+
+        const { result } = renderHook(() => useResetPasswordForm(token));
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(mocks.completeResetPassword).toHaveBeenCalledWith(validPayload);
+        expect(mocks.toastSuccess).toHaveBeenCalledWith(
+            'Password updated successfully. You can sign in now.',
+            expect.objectContaining({
+                duration: 4000,
+                closeButton: true,
+                dismissible: true,
+                className: expect.stringContaining('register-success-toast'),
+            })
+        );
+        expect(mocks.replace).toHaveBeenCalledWith('/signin');
+    });
+
+    it('Shows form error toast when backend returns formError', async () => {
+        mocks.completeResetPassword.mockResolvedValueOnce({
+            success: false,
+            formError: 'Unable to reset password. This link may be invalid or expired.',
+        });
+
+        const { result } = renderHook(() => useResetPasswordForm(token));
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(mocks.toastError).toHaveBeenCalledWith(
+            'Unable to reset password. This link may be invalid or expired.',
+            expect.objectContaining({
+                duration: 4000,
+                closeButton: true,
+                dismissible: true,
+            })
+        );
+        expect(mocks.replace).not.toHaveBeenCalled();
+    });
+
+    it('Maps field errors to react-hook-form state and skips fallback toast', async () => {
+        mocks.completeResetPassword.mockResolvedValueOnce({
+            success: false,
+            fieldErrors: {
+                newPassword: ['Password must be at least 8 characters long'],
+            },
+        });
+
+        const { result } = renderHook(() => useResetPasswordForm(token));
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(result.current.errors.newPassword?.message).toBe('Password must be at least 8 characters long');
+        expect(mocks.toastError).not.toHaveBeenCalled();
+        expect(mocks.replace).not.toHaveBeenCalled();
+    });
+
+    it('Shows fallback error toast when response has no formError and no field errors', async () => {
+        mocks.completeResetPassword.mockResolvedValueOnce({
+            success: false,
+        });
+
+        const { result } = renderHook(() => useResetPasswordForm(token));
+
+        await act(async () => {
+            await result.current.onSubmit(validPayload);
+        });
+
+        expect(mocks.toastError).toHaveBeenCalledWith(
+            'Unable to reset password. Please try again.',
+            expect.objectContaining({
+                duration: 4000,
+                closeButton: true,
+                dismissible: true,
+            })
+        );
+        expect(mocks.replace).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/app/auth/forgot-password/actions.test.ts
+++ b/tests/unit/app/auth/forgot-password/actions.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ForgotPasswordInput } from '@/validation/ForgotPasswordSchema';
+
+const { infoMock, errorMock } = vi.hoisted(() => ({
+    infoMock: vi.fn(),
+    errorMock: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/auth/auth', () => ({
+    auth: {
+        api: {
+            requestPasswordReset: vi.fn(),
+        },
+    },
+}));
+
+vi.mock('@/lib/logging/logger', () => ({
+    logger: {
+        component: () => ({
+            child: () => ({
+                info: infoMock,
+                error: errorMock,
+            }),
+        }),
+    },
+}));
+
+import { auth } from '@/lib/auth/auth';
+import { requestPasswordReset } from '@/app/(auth)/forgot-password/actions';
+
+const ORIGINAL_BETTER_AUTH_URL = process.env.BETTER_AUTH_URL;
+const ORIGINAL_NEXT_PUBLIC_APP_URL = process.env.NEXT_PUBLIC_APP_URL;
+
+describe('Forgot password server action', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        process.env.BETTER_AUTH_URL = ORIGINAL_BETTER_AUTH_URL;
+        process.env.NEXT_PUBLIC_APP_URL = ORIGINAL_NEXT_PUBLIC_APP_URL;
+    });
+
+    it('Returns field errors for invalid forgot-password input', async () => {
+        const result = await requestPasswordReset({
+            email: 'invalid-email',
+        } as ForgotPasswordInput);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.fieldErrors?.email).toContain('Invalid email address');
+        }
+        expect(vi.mocked(auth.api.requestPasswordReset)).not.toHaveBeenCalled();
+    });
+
+    it('Requests password reset, normalizes email, and prefers BETTER_AUTH_URL for redirect base', async () => {
+        process.env.BETTER_AUTH_URL = 'https://auth.linklite.dev/';
+        process.env.NEXT_PUBLIC_APP_URL = 'https://app.linklite.dev';
+
+        vi.mocked(auth.api.requestPasswordReset).mockResolvedValueOnce({
+            status: true,
+            message: 'Password reset email sent',
+        });
+
+        const result = await requestPasswordReset({
+            email: 'JANE@EXAMPLE.COM',
+        });
+
+        expect(vi.mocked(auth.api.requestPasswordReset)).toHaveBeenCalledWith({
+            body: {
+                email: 'jane@example.com',
+                redirectTo: 'https://auth.linklite.dev/reset-password',
+            },
+        });
+        expect(infoMock).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            success: true,
+            message: 'Password reset email sent',
+        });
+    });
+
+    it('Falls back to NEXT_PUBLIC_APP_URL when BETTER_AUTH_URL is not set', async () => {
+        delete process.env.BETTER_AUTH_URL;
+        process.env.NEXT_PUBLIC_APP_URL = 'https://app.linklite.dev/';
+
+        vi.mocked(auth.api.requestPasswordReset).mockResolvedValueOnce({
+            status: true,
+            message: 'Password reset email sent',
+        });
+
+        await requestPasswordReset({
+            email: 'jane@example.com',
+        });
+
+        expect(vi.mocked(auth.api.requestPasswordReset)).toHaveBeenCalledWith({
+            body: {
+                email: 'jane@example.com',
+                redirectTo: 'https://app.linklite.dev/reset-password',
+            },
+        });
+    });
+
+    it('Returns form error when password reset request throws', async () => {
+        vi.mocked(auth.api.requestPasswordReset).mockRejectedValueOnce(new Error('request failed'));
+
+        const result = await requestPasswordReset({
+            email: 'jane@example.com',
+        });
+
+        expect(result).toEqual({
+            success: false,
+            formError: 'Unable to request a password reset right now. Please try again.',
+        });
+        expect(errorMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/app/auth/register/actions.test.ts
+++ b/tests/unit/app/auth/register/actions.test.ts
@@ -46,8 +46,12 @@ describe('Register server action', () => {
         if (!result.success) {
             expect(result.fieldErrors?.name).toContain('Name is too short');
             expect(result.fieldErrors?.email).toContain('Invalid email address');
+            expect(result.fieldErrors?.password).toContain('Password must be at least 8 characters long');
+            expect(result.fieldErrors?.password).toContain('Password must contain at least one uppercase letter');
+            expect(result.fieldErrors?.password).toContain('Password must contain at least one special character (!@#_)');
             expect(result.fieldErrors?.confirmPassword).toContain('Passwords do not match');
             expect(result.fieldErrors?.terms).toContain('You must accept the terms and the privacy policy.');
+            expect(result.formError).toBeUndefined();
         }
         expect(vi.mocked(auth.api.signUpEmail)).not.toHaveBeenCalled();
     });

--- a/tests/unit/app/auth/reset-password/actions.test.ts
+++ b/tests/unit/app/auth/reset-password/actions.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ResetPasswordInput } from '@/validation/ResetPasswordSchema';
+
+const { infoMock, errorMock } = vi.hoisted(() => ({
+    infoMock: vi.fn(),
+    errorMock: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/auth/auth', () => ({
+    auth: {
+        api: {
+            resetPassword: vi.fn(),
+        },
+    },
+}));
+
+vi.mock('@/lib/logging/logger', () => ({
+    logger: {
+        component: () => ({
+            child: () => ({
+                info: infoMock,
+                error: errorMock,
+            }),
+        }),
+    },
+}));
+
+import { auth } from '@/lib/auth/auth';
+import { completeResetPassword } from '@/app/(auth)/reset-password/actions';
+
+describe('Reset password server action', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('Returns field errors for invalid reset-password input', async () => {
+        const result = await completeResetPassword({
+            token: '',
+            newPassword: 'weak',
+            confirmPassword: 'different',
+        } as ResetPasswordInput);
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.fieldErrors?.token).toContain('Invalid reset token');
+            expect(result.fieldErrors?.newPassword).toContain('Password must be at least 8 characters long');
+            expect(result.fieldErrors?.confirmPassword).toContain('Passwords do not match');
+        }
+        expect(vi.mocked(auth.api.resetPassword)).not.toHaveBeenCalled();
+    });
+
+    it('Resets password and returns success message when auth reset succeeds', async () => {
+        vi.mocked(auth.api.resetPassword).mockResolvedValueOnce({
+            status: true,
+        });
+
+        const result = await completeResetPassword({
+            token: 'reset-token-123',
+            newPassword: 'Strong_Ab',
+            confirmPassword: 'Strong_Ab',
+        });
+
+        expect(vi.mocked(auth.api.resetPassword)).toHaveBeenCalledWith({
+            body: {
+                token: 'reset-token-123',
+                newPassword: 'Strong_Ab',
+            },
+        });
+        expect(infoMock).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            success: true,
+            message: 'Password updated successfully. You can sign in now.',
+        });
+    });
+
+    it('Returns form error when auth reset throws', async () => {
+        vi.mocked(auth.api.resetPassword).mockRejectedValueOnce(new Error('reset failed'));
+
+        const result = await completeResetPassword({
+            token: 'reset-token-123',
+            newPassword: 'Strong_Ab',
+            confirmPassword: 'Strong_Ab',
+        });
+
+        expect(result).toEqual({
+            success: false,
+            formError: 'Unable to reset password. This link may be invalid or expired.',
+        });
+        expect(errorMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('Returns the same generic error when auth returns token-specific code', async () => {
+        vi.mocked(auth.api.resetPassword).mockRejectedValueOnce({
+            code: 'INVALID_TOKEN',
+        });
+
+        const result = await completeResetPassword({
+            token: 'reset-token-123',
+            newPassword: 'Strong_Ab',
+            confirmPassword: 'Strong_Ab',
+        });
+
+        expect(result).toEqual({
+            success: false,
+            formError: 'Unable to reset password. This link may be invalid or expired.',
+        });
+    });
+});

--- a/tests/unit/app/auth/signin/actions.test.ts
+++ b/tests/unit/app/auth/signin/actions.test.ts
@@ -45,6 +45,9 @@ describe('Sign in server action', () => {
         if (!result.success) {
             expect(result.fieldErrors?.email).toContain('Invalid email address');
             expect(result.fieldErrors?.password).toContain('Password must be at least 8 characters long');
+            expect(result.fieldErrors?.password).toContain('Password must contain at least one uppercase letter');
+            expect(result.fieldErrors?.password).toContain('Password must contain at least one special character (!@#_)');
+            expect(result.formError).toBeUndefined();
         }
         expect(vi.mocked(auth.api.signInEmail)).not.toHaveBeenCalled();
     });

--- a/tests/unit/lib/server/action_utils.test.ts
+++ b/tests/unit/lib/server/action_utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+
+import { validateAuthActionInput } from '@/lib/server/action_utils';
+
+describe('validateAuthActionInput', () => {
+    it('returns parsed data when input is valid', () => {
+        const schema = z.object({
+            email: z.string().email(),
+        });
+
+        const result = validateAuthActionInput(schema, { email: 'jane@example.com' });
+
+        expect(result.success).toBe(true);
+        if (!result.success) return;
+
+        expect(result.data).toEqual({ email: 'jane@example.com' });
+    });
+
+    it('Returns fieldErrors when input is invalid', () => {
+        const schema = z.object({
+            email: z.string().email(),
+            password: z.string().min(8),
+        });
+
+        const result = validateAuthActionInput(schema, {
+            email: 'not-an-email',
+            password: 'short',
+        });
+
+        expect(result.success).toBe(false);
+        if (result.success) return;
+
+        expect(result.fieldErrors.email).toContain('Invalid email address');
+        expect(result.fieldErrors.password?.[0]).toContain('8');
+    });
+
+    it('Returns empty fieldErrors for root-level refinement errors', () => {
+        const schema = z
+            .object({
+                password: z.string().min(8),
+                confirmPassword: z.string().min(8),
+            })
+            .refine((value) => value.password === value.confirmPassword, {
+                message: 'Passwords must match',
+            });
+
+        const result = validateAuthActionInput(schema, {
+            password: 'Strong_Ab',
+            confirmPassword: 'Strong_Xy',
+        });
+
+        expect(result.success).toBe(false);
+        if (result.success) return;
+
+        expect(result.fieldErrors).toEqual({});
+    });
+});

--- a/tests/unit/validation/forgot_password_schema.test.ts
+++ b/tests/unit/validation/forgot_password_schema.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { ForgotPasswordSchema } from '@/validation/ForgotPasswordSchema';
+
+const validInput = {
+    email: 'jane@example.com',
+};
+
+describe('ForgotPasswordSchema', () => {
+    it('Accepts valid forgot-password payload', () => {
+        const result = ForgotPasswordSchema.safeParse(validInput);
+
+        expect(result.success).toBe(true);
+    });
+
+    it('Rejects invalid email format', () => {
+        const result = ForgotPasswordSchema.safeParse({
+            ...validInput,
+            email: 'invalid-email',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues[0]?.path).toEqual(['email']);
+            expect(result.error.issues[0]?.message).toBe('Invalid email address');
+        }
+    });
+
+    it('Rejects empty email', () => {
+        const result = ForgotPasswordSchema.safeParse({
+            ...validInput,
+            email: '',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues[0]?.path).toEqual(['email']);
+            expect(result.error.issues[0]?.message).toBe('Invalid email address');
+        }
+    });
+});

--- a/tests/unit/validation/reset_password_schema.test.ts
+++ b/tests/unit/validation/reset_password_schema.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { ResetPasswordSchema } from '@/validation/ResetPasswordSchema';
+
+const validInput = {
+    token: 'reset-token-123',
+    newPassword: 'Strong_Ab',
+    confirmPassword: 'Strong_Ab',
+};
+
+describe('ResetPasswordSchema', () => {
+    it('Accepts valid reset-password payload', () => {
+        const result = ResetPasswordSchema.safeParse(validInput);
+
+        expect(result.success).toBe(true);
+    });
+
+    it('Rejects empty reset token', () => {
+        const result = ResetPasswordSchema.safeParse({
+            ...validInput,
+            token: '',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues[0]?.path).toEqual(['token']);
+            expect(result.error.issues[0]?.message).toBe('Invalid reset token');
+        }
+    });
+
+    it('Rejects password shorter than 8 characters', () => {
+        const result = ResetPasswordSchema.safeParse({
+            ...validInput,
+            newPassword: 'Aa_1',
+            confirmPassword: 'Aa_1',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues[0]?.path).toEqual(['newPassword']);
+            expect(result.error.issues[0]?.message).toBe('Password must be at least 8 characters long');
+        }
+    });
+
+    it('Rejects password without lowercase letters', () => {
+        const result = ResetPasswordSchema.safeParse({
+            ...validInput,
+            newPassword: 'STRONG_A',
+            confirmPassword: 'STRONG_A',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues.map((issue) => issue.message)).toContain(
+                'Password must contain at least one lowercase letter'
+            );
+        }
+    });
+
+    it('Rejects password without uppercase letters', () => {
+        const result = ResetPasswordSchema.safeParse({
+            ...validInput,
+            newPassword: 'strong_a',
+            confirmPassword: 'strong_a',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues.map((issue) => issue.message)).toContain(
+                'Password must contain at least one uppercase letter'
+            );
+        }
+    });
+
+    it('Rejects password without required special characters', () => {
+        const result = ResetPasswordSchema.safeParse({
+            ...validInput,
+            newPassword: 'StrongPass',
+            confirmPassword: 'StrongPass',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues.map((issue) => issue.message)).toContain(
+                'Password must contain at least one special character (!@#_)'
+            );
+        }
+    });
+
+    it('Rejects when passwords do not match', () => {
+        const result = ResetPasswordSchema.safeParse({
+            ...validInput,
+            confirmPassword: 'Different_Ab',
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.issues[0]?.path).toEqual(['confirmPassword']);
+            expect(result.error.issues[0]?.message).toBe('Passwords do not match');
+        }
+    });
+});

--- a/validation/ForgotPasswordSchema.ts
+++ b/validation/ForgotPasswordSchema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const ForgotPasswordSchema = z.object({
+    email: z.string().email('Invalid email address'),
+});
+
+export type ForgotPasswordInput = z.infer<typeof ForgotPasswordSchema>;

--- a/validation/ResetPasswordSchema.ts
+++ b/validation/ResetPasswordSchema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const ResetPasswordSchema = z
+    .object({
+        token: z.string().min(1, 'Invalid reset token'),
+        newPassword: z
+            .string()
+            .min(8, 'Password must be at least 8 characters long')
+            .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+            .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+            .regex(/[!@#_]/, 'Password must contain at least one special character (!@#_)'),
+        confirmPassword: z.string(),
+    })
+    .refine((data) => data.newPassword === data.confirmPassword, {
+        message: 'Passwords do not match',
+        path: ['confirmPassword'],
+    });
+
+export type ResetPasswordInput = z.infer<typeof ResetPasswordSchema>;


### PR DESCRIPTION
### Resolves #194 
Changelog:
- Provide auth config for the reset password route
- Provide forgot password navigation within the login form
- Add zod validation for forgot-password form. Provide tests
- Provide common auth action utils. Add tests
- Provide forgot password server action. Add tests
- Provide password reset zod validation schema. Add tests
- Provide server action for resetting out the password. Provide tests
- Refactor register server action. Update tests
- Add custom forget password hook. Add tests
- Provide `ForgetPasswordForm` component. Add tests for it